### PR TITLE
Build Operator bundle and catalog images for deployment on OpenShift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.so
 *.dylib
 bin
+bundle_tmp*
 testbin/*
 Dockerfile.cross
 
@@ -25,3 +26,5 @@ Dockerfile.cross
 *.swp
 *.swo
 *~
+.vscode/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -45,6 +45,27 @@ UnDeploy the controller from the cluster:
 ```sh
 make undeploy
 ```
+## Build and Deploy with OLM
+1. To build operator, bundle and catalog images:
+```sh
+make release-build
+```
+2. To push operator, bundle and catalog images to the registry:
+```sh
+make release-push
+```
+3. To deploy or update catalog source:
+```sh
+make catalog-update
+```
+4. To deloy the operator with OLM
+```sh
+make deploy-olm
+```
+4. To undeloy the operator with OLM
+```sh
+make undeploy-olm
+```
 ## Contributing
 // TODO(user): Add detailed information on how you would like others to contribute to this project
 

--- a/config/samples/catalog-operator-group.yaml
+++ b/config/samples/catalog-operator-group.yaml
@@ -1,0 +1,4 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: backstage-operator-group

--- a/config/samples/catalog-source-template.yaml
+++ b/config/samples/catalog-source-template.yaml
@@ -1,0 +1,9 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: backstage-operator
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: {{CATALOG_IMG}}
+  displayName: Backstage Operator

--- a/config/samples/catalog-source.yaml
+++ b/config/samples/catalog-source.yaml
@@ -1,0 +1,9 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: backstage-operator
+  namespace: openshift-marketplace
+spec:
+  sourceType: grpc
+  image: quay.io/rhdh/backstage-operator-catalog:v0.0.1
+  displayName: Backstage Operator

--- a/config/samples/catalog-subscription.yaml
+++ b/config/samples/catalog-subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: backstage-operator
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: backstage-operator
+  source: backstage-operator
+  sourceNamespace: openshift-marketplace
+  startingCSV: backstage-operator.v0.0.1


### PR DESCRIPTION
This PR replaces previous one: https://github.com/janus-idp/operator/pull/18

Fixes https://github.com/janus-idp/operator/issues/9

To build operator, bundle and catalog images:
make release-build
To push operator, bundle and catalog images to the registry:
make release-push
To deploy or update catalog source:
make catalog-update
To deloy the operator with OLM
make deploy-olm
To undeloy the operator with OLM
make undeploy-olm