### PR TITLE
Check in CI that the `{podman,docker}-build` Make targets pass

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,4 +17,15 @@ jobs:
     - name: Build
       run: make test
 
+  container-image-build:
+    runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        engine: [docker, podman]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: ${{ matrix.engine }}-build
+        run: make ${{ matrix.engine }}-build


### PR DESCRIPTION
While reviewing https://github.com/janus-idp/operator/pull/25 and finding out that the `podman-build` target was not passing, I thought it would make sense to have this enforced in CI.

**NOTES**:
Currently, all of the targets used in this Workflow depend on the `test` target. This makes the `test` target run twice, which is unnecessary. This could be something to optimize later on.