### PR TITLE
Implement routing configuration for Backstage server endpoint

### DIFF
--- a/bundle/manifests/backstage-default-config_v1_configmap.yaml
+++ b/bundle/manifests/backstage-default-config_v1_configmap.yaml
@@ -137,7 +137,7 @@ data:
     apiVersion: apps/v1
     kind: Deployment
     metadata:
-      name: backstage
+      name:  # placeholder for 'backstage-<cr-name>'
     spec:
       replicas: 1
       selector:
@@ -212,7 +212,7 @@ data:
                 successThreshold: 1
                 timeoutSeconds: 2
               ports:
-                - name: http
+                - name: backend
                   containerPort: 7007
               env:
                 - name: APP_CONFIG_backend_listen_port
@@ -235,19 +235,34 @@ data:
         includes:
           - dynamic-plugins.default.yaml
         plugins: []
+  route.yaml: |-
+    apiVersion: route.openshift.io/v1
+    kind: Route
+    metadata:
+      name:  # placeholder for 'backstage-<cr-name>'
+    spec:
+      port:
+        targetPort: http-backend
+      path: /
+      tls:
+        insecureEdgeTerminationPolicy: Redirect
+        termination: edge
+      to:
+        kind: Service
+        name:  # placeholder for 'backstage-<cr-name>'
   service.yaml: |-
     apiVersion: v1
     kind: Service
     metadata:
-      name: backstage
+      name: # placeholder for 'backstage-<cr-name>'
     spec:
-      type: NodePort
+      type: ClusterIP
       selector:
         janus-idp.io/app:  # placeholder for 'backstage-<cr-name>'
       ports:
-        - name: http
-          port: 80
-          targetPort: http
+        - name: http-backend
+          port: 7007
+          targetPort: backend
 kind: ConfigMap
 metadata:
   name: backstage-default-config

--- a/bundle/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/backstage-operator.clusterserviceversion.yaml
@@ -107,6 +107,17 @@ spec:
           - patch
           - update
         - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
           - authentication.k8s.io
           resources:
           - tokenreviews

--- a/config/manager/default-config/deployment.yaml
+++ b/config/manager/default-config/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: backstage
+  name:  # placeholder for 'backstage-<cr-name>'
 spec:
   replicas: 1
   selector:
@@ -76,7 +76,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 2
           ports:
-            - name: http
+            - name: backend
               containerPort: 7007
           env:
             - name: APP_CONFIG_backend_listen_port

--- a/config/manager/default-config/route.yaml
+++ b/config/manager/default-config/route.yaml
@@ -1,0 +1,14 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name:  # placeholder for 'backstage-<cr-name>'
+spec:
+  port:
+    targetPort: http-backend
+  path: /
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name:  # placeholder for 'backstage-<cr-name>'

--- a/config/manager/default-config/service.yaml
+++ b/config/manager/default-config/service.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: backstage
+  name: # placeholder for 'backstage-<cr-name>'
 spec:
-  type: NodePort
+  type: ClusterIP
   selector:
     janus-idp.io/app:  # placeholder for 'backstage-<cr-name>'
   ports:
-    - name: http
-      port: 80
-      targetPort: http
+    - name: http-backend
+      port: 7007
+      targetPort: backend

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -14,6 +14,7 @@ configMapGenerator:
 - files:
   - default-config/deployment.yaml
   - default-config/service.yaml
+  - default-config/route.yaml
   - default-config/db-statefulset.yaml
   - default-config/db-service.yaml
   - default-config/db-service-hl.yaml

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -68,3 +68,14 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch

--- a/controllers/backstage_controller_test.go
+++ b/controllers/backstage_controller_test.go
@@ -189,7 +189,7 @@ var _ = Describe("Backstage controller", func() {
 			found := &appsv1.Deployment{}
 			Eventually(func() error {
 				// TODO to get name from default
-				return k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "backstage"}, found)
+				return k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: fmt.Sprintf("backstage-%s", backstageName)}, found)
 			}, time.Minute, time.Second).Should(Succeed())
 
 			By("Checking that the Deployment is configured with a random backend auth secret")
@@ -338,7 +338,7 @@ spec:
 				By("Checking if Deployment was successfully created in the reconciliation")
 				Eventually(func() error {
 					found := &appsv1.Deployment{}
-					return k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "bs1-deployment"}, found)
+					return k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: fmt.Sprintf("backstage-%s", backstageName)}, found)
 				}, time.Minute, time.Second).Should(Succeed())
 
 				By("Checking the latest Status added to the Backstage instance")
@@ -457,7 +457,7 @@ spec:
 					By("Not creating a Backstage Deployment")
 					Consistently(func() error {
 						// TODO to get name from default
-						return k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "backstage"}, &appsv1.Deployment{})
+						return k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: fmt.Sprintf("backstage-%s", backstageName)}, &appsv1.Deployment{})
 					}, 5*time.Second, time.Second).Should(Not(Succeed()))
 				})
 			})
@@ -558,7 +558,7 @@ plugins: []
 					found := &appsv1.Deployment{}
 					Eventually(func(g Gomega) {
 						// TODO to get name from default
-						err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "backstage"}, found)
+						err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: fmt.Sprintf("backstage-%s", backstageName)}, found)
 						g.Expect(err).To(Not(HaveOccurred()))
 					}, time.Minute, time.Second).Should(Succeed())
 
@@ -733,7 +733,7 @@ plugins: []
 					found := &appsv1.Deployment{}
 					Eventually(func() error {
 						// TODO to get name from default
-						return k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "backstage"}, found)
+						return k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: fmt.Sprintf("backstage-%s", backstageName)}, found)
 					}, time.Minute, time.Second).Should(Succeed())
 
 					By("Checking that the Deployment is configured with the specified secret", func() {
@@ -808,7 +808,7 @@ plugins: []
 					found := &appsv1.Deployment{}
 					Eventually(func() error {
 						// TODO to get name from default
-						return k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "backstage"}, found)
+						return k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: fmt.Sprintf("backstage-%s", backstageName)}, found)
 					}, time.Minute, time.Second).Should(Succeed())
 
 					By("Checking that the Deployment is configured with the specified secret", func() {

--- a/controllers/backstage_deployment.go
+++ b/controllers/backstage_deployment.go
@@ -139,7 +139,9 @@ func (r *BackstageReconciler) applyBackstageDeployment(ctx context.Context, back
 	}
 
 	foundDeployment := &appsv1.Deployment{}
-	err = r.Get(ctx, types.NamespacedName{Name: deployment.Name, Namespace: ns}, foundDeployment)
+	name := fmt.Sprintf("backstage-%s", backstage.Name)
+	deployment.Name = name
+	err = r.Get(ctx, types.NamespacedName{Name: name, Namespace: ns}, foundDeployment)
 	if err != nil {
 		if errors.IsNotFound(err) {
 

--- a/controllers/backstage_route.go
+++ b/controllers/backstage_route.go
@@ -20,50 +20,45 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	openshift "github.com/openshift/api/route/v1"
 	bs "janus-idp.io/backstage-operator/api/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// selector for deploy.spec.template.spec.meta.label
-// targetPort: http for deploy.spec.template.spec.containers.ports.name=http
-func (r *BackstageReconciler) applyBackstageService(ctx context.Context, backstage bs.Backstage, ns string) error {
-
-	//lg := log.FromContext(ctx)
-
-	service := &corev1.Service{}
-	err := r.readConfigMapOrDefault(ctx, backstage.Spec.RawRuntimeConfig.BackstageConfigName, "service.yaml", ns, service)
+func (r *BackstageReconciler) applyBackstageRoute(ctx context.Context, backstage bs.Backstage, ns string) error {
+	route := &openshift.Route{}
+	err := r.readConfigMapOrDefault(ctx, backstage.Spec.RawRuntimeConfig.BackstageConfigName, "route.yaml", ns, route)
 	if err != nil {
 		return err
 	}
+
+	// Override the route and service names
 	name := fmt.Sprintf("backstage-%s", backstage.Name)
-	service.Name = name
+	route.Name = name
+	route.Spec.To.Name = name
 
-	setBackstageAppLabel(&service.Spec.Selector, backstage)
-
-	err = r.Get(ctx, types.NamespacedName{Name: service.Name, Namespace: ns}, service)
+	err = r.Get(ctx, types.NamespacedName{Name: route.Name, Namespace: ns}, route)
 	if err != nil {
-		if errors.IsNotFound(err) {
-		} else {
-			return fmt.Errorf("failed to get backstage service, reason: %s", err)
+		if !errors.IsNotFound(err) {
+			return fmt.Errorf("failed to get backstage route, reason: %s", err)
 		}
 	} else {
 		//lg.Info("CR update is ignored for the time")
 		return nil
 	}
 
-	r.labels(&service.ObjectMeta, backstage)
+	r.labels(&route.ObjectMeta, backstage)
 
 	if r.OwnsRuntime {
-		if err := controllerutil.SetControllerReference(&backstage, service, r.Scheme); err != nil {
+		if err := controllerutil.SetControllerReference(&backstage, route, r.Scheme); err != nil {
 			return fmt.Errorf("failed to set owner reference: %s", err)
 		}
 	}
 
-	err = r.Create(ctx, service)
+	err = r.Create(ctx, route)
 	if err != nil {
-		return fmt.Errorf("failed to create backstage service, reason: %s", err)
+		return fmt.Errorf("failed to create backstage route, reason: %s", err)
 	}
 	return nil
 }

--- a/controllers/local_db_statefulset.go
+++ b/controllers/local_db_statefulset.go
@@ -167,6 +167,10 @@ func (r *BackstageReconciler) applyLocalDbStatefulSet(ctx context.Context, backs
 		return err
 	}
 
+	if err = r.patchLocalDbStatefulSetObj(statefulSet, backstage); err != nil {
+		return err
+	}
+
 	err = r.Get(ctx, types.NamespacedName{Name: statefulSet.Name, Namespace: ns}, statefulSet)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -198,10 +202,6 @@ func (r *BackstageReconciler) applyLocalDbStatefulSet(ctx context.Context, backs
 	}
 
 	r.labels(&statefulSet.ObjectMeta, backstage)
-	if err = r.patchLocalDbStatefulSetObj(statefulSet, backstage); err != nil {
-		return err
-	}
-
 	err = r.Create(ctx, statefulSet)
 	if err != nil {
 		return fmt.Errorf("failed to create statefulset, reason: %s", err)
@@ -211,14 +211,13 @@ func (r *BackstageReconciler) applyLocalDbStatefulSet(ctx context.Context, backs
 }
 
 func (r *BackstageReconciler) applyLocalDbServices(ctx context.Context, backstage bs.Backstage, ns string) error {
-	// TODO static for the time and bound to Secret: postgres-secret
-	label := fmt.Sprintf("backstage-psql-%s", backstage.Name)
-	err := r.applyPsqlService(ctx, backstage, "backstage-psql", label, ns, "db-service.yaml")
+	name := fmt.Sprintf("backstage-psql-%s", backstage.Name)
+	err := r.applyPsqlService(ctx, backstage, name, name, ns, "db-service.yaml")
 	if err != nil {
 		return err
 	}
 	nameHL := fmt.Sprintf("backstage-psql-%s-hl", backstage.Name)
-	return r.applyPsqlService(ctx, backstage, nameHL, label, ns, "db-service-hl.yaml")
+	return r.applyPsqlService(ctx, backstage, nameHL, name, ns, "db-service-hl.yaml")
 
 }
 

--- a/examples/janus-cr.yaml
+++ b/examples/janus-cr.yaml
@@ -4,6 +4,6 @@ metadata:
   name: bs-janus
   namespace: backstage
 spec:
-  runtimeConfig:
+  rawRuntimeConfig:
     backstageConfig: janus-config
 #  dryRun: true


### PR DESCRIPTION
Deploy an OpenShift route on OpenShift clusters.
## Description
Changes made:
1) Autodetect if the current cluster is OpenShift and creates a route when Backstage CR is reconciled.
2) Changed backstage deployment and service name to "backstage-"+<CR name> to allow the users to deploy multiple backstage CRs in the same namespace.
3) Changed the default value of own-runtien to true.

Note #1: supporting host and tls in the route via Backstage CR is not in the scope of this PR. Such work shall be done later as a separate PR after the data model has been finalized.

Note #2: unit test with isOpenShift=true is not included as OpenShift specific objects (routes, projects etc) are not currently supported by the envTest tool (see https://github.com/operator-framework/operator-sdk/issues/4434). 

## Which issue(s) does this PR fix or relate to

- Fixes #13

## PR acceptance criteria

- [X] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
Deploy the operator and backstage sample CR on an OpnenShift cluster and check if the OpenShift route for Backstage has been created.

