### PR TITLE
Delete local Postgres resources when Backstage CR is deleted

### DIFF
--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/bundle/manifests/backstage-default-config_v1_configmap.yaml
+++ b/bundle/manifests/backstage-default-config_v1_configmap.yaml
@@ -46,6 +46,9 @@ data:
             janus-idp.io/app: backstage-psql-cr1 # placeholder for 'backstage-psql-<cr-name>'
           name: backstage-db-cr1 # placeholder for 'backstage-psql-<cr-name>'
         spec:
+          persistentVolumeClaimRetentionPolicy:
+            whenDeleted: Retain
+            whenScaled: Retain
           containers:
             - env:
                 - name: POSTGRESQL_PORT_NUMBER

--- a/bundle/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/backstage-operator.clusterserviceversion.yaml
@@ -49,6 +49,7 @@ spec:
           - configmaps
           - persistentvolumeclaims
           - persistentvolumes
+          - secrets
           - services
           verbs:
           - create

--- a/config/manager/default-config/db-statefulset.yaml
+++ b/config/manager/default-config/db-statefulset.yaml
@@ -15,6 +15,9 @@ spec:
         janus-idp.io/app: backstage-psql-cr1 # placeholder for 'backstage-psql-<cr-name>'
       name: backstage-db-cr1 # placeholder for 'backstage-psql-<cr-name>'
     spec:
+      persistentVolumeClaimRetentionPolicy:
+        whenDeleted: Retain
+        whenScaled: Retain
       containers:
         - env:
             - name: POSTGRESQL_PORT_NUMBER

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -11,6 +11,7 @@ rules:
   - configmaps
   - persistentvolumeclaims
   - persistentvolumes
+  - secrets
   - services
   verbs:
   - create

--- a/config/samples/catalog-source-template.yaml
+++ b/config/samples/catalog-source-template.yaml
@@ -2,7 +2,6 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
   name: backstage-operator
-  namespace: openshift-marketplace
 spec:
   sourceType: grpc
   image: {{CATALOG_IMG}}

--- a/controllers/backstage_controller.go
+++ b/controllers/backstage_controller.go
@@ -56,7 +56,7 @@ type BackstageReconciler struct {
 //+kubebuilder:rbac:groups=janus-idp.io,resources=backstages,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=janus-idp.io,resources=backstages/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=janus-idp.io,resources=backstages/finalizers,verbs=update
-//+kubebuilder:rbac:groups="",resources=configmaps;persistentvolumes;persistentvolumeclaims;services,verbs=get;watch;create;update;list;delete
+//+kubebuilder:rbac:groups="",resources=configmaps;secrets;persistentvolumes;persistentvolumeclaims;services,verbs=get;watch;create;update;list;delete
 //+kubebuilder:rbac:groups="apps",resources=deployments,verbs=get;watch;create;update;list;delete
 //+kubebuilder:rbac:groups="apps",resources=statefulsets,verbs=get;watch;create;update;list;delete
 
@@ -101,7 +101,7 @@ func (r *BackstageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 		err := r.applyLocalDbStatefulSet(ctx, backstage, req.Namespace)
 		if err != nil {
-			return ctrl.Result{}, fmt.Errorf("failed to apply Database Deployment: %w", err)
+			return ctrl.Result{}, fmt.Errorf("failed to apply Database StatefulSet: %w", err)
 		}
 
 		err = r.applyLocalDbServices(ctx, backstage, req.Namespace)

--- a/controllers/local_db_statefulset.go
+++ b/controllers/local_db_statefulset.go
@@ -19,12 +19,14 @@ import (
 	"context"
 	"fmt"
 
-	bs "janus-idp.io/backstage-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	bs "janus-idp.io/backstage-operator/api/v1alpha1"
 )
 
 //var (
@@ -153,6 +155,8 @@ import (
 //`
 //)
 
+const ownerRefFmt = "failed to set owner reference: %s"
+
 func (r *BackstageReconciler) applyLocalDbStatefulSet(ctx context.Context, backstage bs.Backstage, ns string) error {
 
 	lg := log.FromContext(ctx)
@@ -163,17 +167,34 @@ func (r *BackstageReconciler) applyLocalDbStatefulSet(ctx context.Context, backs
 		return err
 	}
 
-	//deployment.Namespace = ns
 	err = r.Get(ctx, types.NamespacedName{Name: statefulSet.Name, Namespace: ns}, statefulSet)
 	if err != nil {
 		if errors.IsNotFound(err) {
 
 		} else {
-			return fmt.Errorf("failed to get deployment, reason: %s", err)
+			return fmt.Errorf(ownerRefFmt, err)
 		}
 	} else {
 		lg.Info("CR update is ignored for the time")
 		return nil
+	}
+
+	if r.OwnsRuntime {
+		// Set the ownerreferences for the statefulset so that when the backstage CR is deleted,
+		// the statefulset is automatically deleted
+		// Note that the PVCs associated with the statefulset are not deleted automatically
+		// to prevent data loss. However OpenShift v4.14 and Kubernetes v1.27 introduced an optional
+		// parameter persistentVolumeClaimRetentionPolicy in the statefulset spec:
+		// spec:
+		//   persistentVolumeClaimRetentionPolicy:
+		//     whenDeleted: Delete
+		//     whenScaled: Retain
+		// This will allow the PVCs to get automatically deleted when the statefulset is deleted if
+		// the StatefulSetAutoDeletePVC feature gate is enabled on the API server.
+		// For more information, see https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
+		if err := controllerutil.SetControllerReference(&backstage, statefulSet, r.Scheme); err != nil {
+			return fmt.Errorf(ownerRefFmt, err)
+		}
 	}
 
 	r.labels(&statefulSet.ObjectMeta, backstage)
@@ -183,7 +204,7 @@ func (r *BackstageReconciler) applyLocalDbStatefulSet(ctx context.Context, backs
 
 	err = r.Create(ctx, statefulSet)
 	if err != nil {
-		return fmt.Errorf("failed to create deplyment, reason: %s", err)
+		return fmt.Errorf("failed to create statefulset, reason: %s", err)
 	}
 
 	return nil
@@ -224,6 +245,13 @@ func (r *BackstageReconciler) applyPsqlService(ctx context.Context, backstage bs
 		lg.Info("CR update is ignored for the time")
 		return nil
 	}
+
+	if r.OwnsRuntime {
+		if err := controllerutil.SetControllerReference(&backstage, service, r.Scheme); err != nil {
+			return fmt.Errorf(ownerRefFmt, err)
+		}
+	}
+
 	err = r.Create(ctx, service)
 	if err != nil {
 		return fmt.Errorf("failed to create service, reason: %s", err)

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.BoolVar(&ownRuntime, "own-runtime", false, "Making Backstage Controller own runtime objects. "+
+	flag.BoolVar(&ownRuntime, "own-runtime", true, "Making Backstage Controller own runtime objects. "+
 		"If 'true' - all runtime objects created by Controller will be syncing with desired state configured by Controller")
 
 	opts := zap.Options{


### PR DESCRIPTION
## Description
When the backstage CR is deleted, the statefulset and services created for the local db should also be deleted automatically.

Note that the PVCs are NOT automatically deleted to prevent data loss. However OpenShift v4.14 and Kubernetes v1.27 introduced an optional parameter persistentVolumeClaimRetentionPolicy in the statefulset spec:
to allow the PVCs to get automatically deleted when the statefulset is deleted if the StatefulSetAutoDeletePVC feature gate is enabled on the API server.

Additional changes:
1) Changed the default value of own-runtime to true.
2) Added secrets to RBAC.

## Which issue(s) does this PR fix or relate to

- Fixes #55

## PR acceptance criteria

- [X] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
Delete the backstage CR and confirm that the db statefulset and services are auto deleted.
