### PR TITLE
Implement routing configuration for Backstage server endpoint

### DIFF
--- a/bundle/manifests/backstage-default-config_v1_configmap.yaml
+++ b/bundle/manifests/backstage-default-config_v1_configmap.yaml
@@ -142,7 +142,7 @@ data:
     apiVersion: apps/v1
     kind: Deployment
     metadata:
-      name: backstage
+      name:  # placeholder for 'backstage-<cr-name>'
     spec:
       replicas: 1
       selector:
@@ -217,7 +217,7 @@ data:
                 successThreshold: 1
                 timeoutSeconds: 2
               ports:
-                - name: http
+                - name: backend
                   containerPort: 7007
               env:
                 - name: APP_CONFIG_backend_listen_port
@@ -240,19 +240,34 @@ data:
         includes:
           - dynamic-plugins.default.yaml
         plugins: []
+  route.yaml: |-
+    apiVersion: route.openshift.io/v1
+    kind: Route
+    metadata:
+      name:  # placeholder for 'backstage-<cr-name>'
+    spec:
+      port:
+        targetPort: http-backend
+      path: /
+      tls:
+        insecureEdgeTerminationPolicy: Redirect
+        termination: edge
+      to:
+        kind: Service
+        name:  # placeholder for 'backstage-<cr-name>'
   service.yaml: |-
     apiVersion: v1
     kind: Service
     metadata:
-      name: backstage
+      name:  # placeholder for 'backstage-<cr-name>'
     spec:
-      type: NodePort
+      type: ClusterIP
       selector:
         janus-idp.io/app:  # placeholder for 'backstage-<cr-name>'
       ports:
-        - name: http
+        - name: http-backend
           port: 80
-          targetPort: http
+          targetPort: backend
 kind: ConfigMap
 metadata:
   name: backstage-default-config

--- a/bundle/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/backstage-operator.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-12-11T15:41:14Z"
+    createdAt: "2023-12-12T16:11:34Z"
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: backstage-operator.v0.0.1
@@ -107,6 +107,17 @@ spec:
           - get
           - patch
           - update
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
         - apiGroups:
           - authentication.k8s.io
           resources:

--- a/config/manager/default-config/deployment.yaml
+++ b/config/manager/default-config/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: backstage
+  name:  # placeholder for 'backstage-<cr-name>'
 spec:
   replicas: 1
   selector:
@@ -76,7 +76,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 2
           ports:
-            - name: http
+            - name: backend
               containerPort: 7007
           env:
             - name: APP_CONFIG_backend_listen_port

--- a/config/manager/default-config/route.yaml
+++ b/config/manager/default-config/route.yaml
@@ -1,0 +1,14 @@
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name:  # placeholder for 'backstage-<cr-name>'
+spec:
+  port:
+    targetPort: http-backend
+  path: /
+  tls:
+    insecureEdgeTerminationPolicy: Redirect
+    termination: edge
+  to:
+    kind: Service
+    name:  # placeholder for 'backstage-<cr-name>'

--- a/config/manager/default-config/service.yaml
+++ b/config/manager/default-config/service.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: backstage
+  name:  # placeholder for 'backstage-<cr-name>'
 spec:
-  type: NodePort
+  type: ClusterIP
   selector:
     janus-idp.io/app:  # placeholder for 'backstage-<cr-name>'
   ports:
-    - name: http
+    - name: http-backend
       port: 80
-      targetPort: http
+      targetPort: backend

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -14,6 +14,7 @@ configMapGenerator:
 - files:
   - default-config/deployment.yaml
   - default-config/service.yaml
+  - default-config/route.yaml
   - default-config/db-statefulset.yaml
   - default-config/db-service.yaml
   - default-config/db-service-hl.yaml

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -68,3 +68,14 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch

--- a/controllers/backstage_controller.go
+++ b/controllers/backstage_controller.go
@@ -52,6 +52,8 @@ type BackstageReconciler struct {
 	// and ignore requests from other namespaces.
 	// This is mostly useful for our tests, to overcome a limitation of EnvTest about namespace deletion.
 	Namespace string
+
+	IsOpenShift bool
 }
 
 //+kubebuilder:rbac:groups=janus-idp.io,resources=backstages,verbs=get;list;watch;create;update;patch;delete
@@ -60,6 +62,7 @@ type BackstageReconciler struct {
 //+kubebuilder:rbac:groups="",resources=configmaps;secrets;persistentvolumes;persistentvolumeclaims;services,verbs=get;watch;create;update;list;delete
 //+kubebuilder:rbac:groups="apps",resources=deployments,verbs=get;watch;create;update;list;delete
 //+kubebuilder:rbac:groups="apps",resources=statefulsets,verbs=get;watch;create;update;list;delete
+//+kubebuilder:rbac:groups="route.openshift.io",resources=routes,verbs=get;watch;create;update;list;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -119,6 +122,12 @@ func (r *BackstageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	if err := r.applyBackstageService(ctx, backstage, req.Namespace); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to apply Backstage Service: %w", err)
+	}
+
+	if r.IsOpenShift {
+		if err := r.applyBackstageRoute(ctx, backstage, req.Namespace); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	//TODO: it is just a placeholder for the time

--- a/controllers/backstage_controller_test.go
+++ b/controllers/backstage_controller_test.go
@@ -221,7 +221,7 @@ var _ = Describe("Backstage controller", func() {
 			found := &appsv1.Deployment{}
 			Eventually(func() error {
 				// TODO to get name from default
-				return k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "backstage"}, found)
+				return k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: fmt.Sprintf("backstage-%s", backstageName)}, found)
 			}, time.Minute, time.Second).Should(Succeed())
 
 			By("checking the number of replicas")
@@ -370,7 +370,7 @@ spec:
 				By("Checking if Deployment was successfully created in the reconciliation")
 				Eventually(func() error {
 					found := &appsv1.Deployment{}
-					return k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "bs1-deployment"}, found)
+					return k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: fmt.Sprintf("backstage-%s", backstageName)}, found)
 				}, time.Minute, time.Second).Should(Succeed())
 
 				By("Checking the latest Status added to the Backstage instance")
@@ -488,7 +488,7 @@ spec:
 				By("Not creating a Backstage Deployment")
 				Consistently(func() error {
 					// TODO to get name from default
-					return k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "backstage"}, &appsv1.Deployment{})
+					return k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: fmt.Sprintf("backstage-%s", backstageName)}, &appsv1.Deployment{})
 				}, 5*time.Second, time.Second).Should(Not(Succeed()))
 			})
 		})
@@ -563,7 +563,7 @@ plugins: []
 							found := &appsv1.Deployment{}
 							Eventually(func(g Gomega) {
 								// TODO to get name from default
-								err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "backstage"}, found)
+								err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: fmt.Sprintf("backstage-%s", backstageName)}, found)
 								g.Expect(err).To(Not(HaveOccurred()))
 							}, time.Minute, time.Second).Should(Succeed())
 
@@ -749,7 +749,7 @@ plugins: []
 					By("Not creating a Backstage Deployment")
 					Consistently(func() error {
 						// TODO to get name from default
-						return k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "backstage"}, &appsv1.Deployment{})
+						return k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: fmt.Sprintf("backstage-%s", backstageName)}, &appsv1.Deployment{})
 					}, 5*time.Second, time.Second).Should(Not(Succeed()))
 				})
 			})
@@ -848,7 +848,7 @@ plugins: []
 					found := &appsv1.Deployment{}
 					Eventually(func(g Gomega) {
 						// TODO to get name from default
-						err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "backstage"}, found)
+						err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: fmt.Sprintf("backstage-%s", backstageName)}, found)
 						g.Expect(err).To(Not(HaveOccurred()))
 					}, time.Minute, time.Second).Should(Succeed())
 
@@ -859,7 +859,7 @@ plugins: []
 						Expect(ok).To(BeTrue(), "No volume found with name: %s", extraConfig1CmNameAll)
 						Expect(extraConfig1CmVol.VolumeSource.Secret).To(BeNil())
 						Expect(extraConfig1CmVol.VolumeSource.ConfigMap.DefaultMode).To(HaveValue(Equal(int32(420))))
-						Expect(extraConfig1CmVol.VolumeSource.ConfigMap.LocalObjectReference.Name).To(Equal(extraConfig1CmNameAll))
+						Expect(extraConfig1CmVol.VolumeSource.ConfigMap.Looc get calObjectReference.Name).To(Equal(extraConfig1CmNameAll))
 
 						extraConfig2SecretVol, ok := findVolume(found.Spec.Template.Spec.Volumes, extraConfig2SecretNameAll)
 						Expect(ok).To(BeTrue(), "No volume found with name: %s", extraConfig2SecretNameAll)
@@ -1024,7 +1024,7 @@ plugins: []
 				found := &appsv1.Deployment{}
 				Eventually(func(g Gomega) {
 					// TODO to get name from default
-					err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "backstage"}, found)
+					err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: fmt.Sprintf("backstage-%s", backstageName)}, found)
 					g.Expect(err).To(Not(HaveOccurred()))
 				}, time.Minute, time.Second).Should(Succeed())
 
@@ -1134,7 +1134,7 @@ plugins: []
 			found := &appsv1.Deployment{}
 			Eventually(func(g Gomega) {
 				// TODO to get name from default
-				err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "backstage"}, found)
+				err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: fmt.Sprintf("backstage-%s", backstageName)}, found)
 				g.Expect(err).To(Not(HaveOccurred()))
 			}, time.Minute, time.Second).Should(Succeed())
 
@@ -1185,7 +1185,7 @@ plugins: []
 			found := &appsv1.Deployment{}
 			Eventually(func(g Gomega) {
 				// TODO to get name from default
-				err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "backstage"}, found)
+				err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: fmt.Sprintf("backstage-%s", backstageName)}, found)
 				g.Expect(err).To(Not(HaveOccurred()))
 			}, time.Minute, time.Second).Should(Succeed())
 
@@ -1234,7 +1234,7 @@ plugins: []
 			found := &appsv1.Deployment{}
 			Eventually(func(g Gomega) {
 				// TODO to get name from default
-				err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "backstage"}, found)
+				err := k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: fmt.Sprintf("backstage-%s", backstageName)}, found)
 				g.Expect(err).To(Not(HaveOccurred()))
 			}, time.Minute, time.Second).Should(Succeed())
 
@@ -1284,7 +1284,7 @@ plugins: []
 				By("Checking if Deployment was successfully created in the reconciliation")
 				Eventually(func() error {
 					// TODO to get name from default
-					return k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: "backstage"}, &appsv1.Deployment{})
+					return k8sClient.Get(ctx, types.NamespacedName{Namespace: ns, Name: fmt.Sprintf("backstage-%s", backstageName)}, &appsv1.Deployment{})
 				}, time.Minute, time.Second).Should(Succeed())
 
 				By("Checking the latest Status added to the Backstage instance")

--- a/controllers/backstage_deployment.go
+++ b/controllers/backstage_deployment.go
@@ -156,6 +156,7 @@ func (r *BackstageReconciler) applyBackstageDeployment(ctx context.Context, back
 	}
 
 	foundDeployment := &appsv1.Deployment{}
+	deployment.Name = fmt.Sprintf("backstage-%s", backstage.Name)
 	err = r.Get(ctx, types.NamespacedName{Name: deployment.Name, Namespace: ns}, foundDeployment)
 	if err != nil {
 		if errors.IsNotFound(err) {

--- a/examples/postgres-secret.yaml
+++ b/examples/postgres-secret.yaml
@@ -9,4 +9,4 @@ stringData:
   POSTGRES_PORT: "5432"
   POSTGRES_USER: postgres
   POSTGRESQL_ADMIN_PASSWORD: admin123
-  POSTGRES_HOST: backstage-psql
+  POSTGRES_HOST: backstage-psql-bs1


### PR DESCRIPTION
Changes made:
1. Autodetect if the current cluster is OpenShift and creates a route when Backstage CR is reconciled.
2. Changed backstage deployment and service name to "backstage-"+ to allow the users to deploy multiple backstage CRs in the same namespace.
3. Changed the default value of own-runtien to true.
Note [#1](https://github.com/janus-idp/operator/issues/1): supporting host and tls in the route via Backstage CR is not in the scope of this PR. Such work shall be done later as a separate PR after the data model has been finalized.
Note [#2](https://github.com/janus-idp/operator/pull/2): unit test with isOpenShift=true is not included as OpenShift specific objects (routes, projects etc) are not currently supported by the envTest tool (see [operator-framework/operator-sdk#4434](https://github.com/operator-framework/operator-sdk/issues/4434)).

## Which issue(s) does this PR fix or relate to

- Fixes #53 
## PR acceptance criteria

- [ X] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
1) Deploy the operator  on OpenShift and create the postgres secret (make sure POSTGRES_HOST is set to "backstage-psql-<your CR name>", and create backstage CR.
2) Check that a route has been created:
oc get route
NAME            HOST/PORT                                                        PATH   SERVICES        PORT           TERMINATION     WILDCARD
backstage-bs1   backstage-bs1-backstage.apps.cluster-s4l2f.dynamic.opentlc.com   /      backstage-bs1   http-backend   edge/Redirect   None
3) Now check if you can open the page in your browser:
https://<route host>
