### PR TITLE
extract postgres image ref to an env var RELATED_IMAGE_postgresql in CSV (airgap support)

### DIFF
--- a/bundle/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/backstage-operator.clusterserviceversion.yaml
@@ -195,6 +195,9 @@ spec:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
+                env:
+                - name: RELATED_IMAGE_postgresql
+                  value: registry.redhat.io/rhel9/postgresql-15:latest
                 command:
                 - /manager
                 image: quay.io/rhdh/backstage-operator:v0.0.1

--- a/config/manager/default-config/db-statefulset.yaml
+++ b/config/manager/default-config/db-statefulset.yaml
@@ -28,8 +28,8 @@ spec:
               value: /var/lib/pgsql/data/userdata
           envFrom:
             - secretRef:
-                name: "{POSTGRESQL_SECRET}"  # will be replaced with 'backstage-psql-secrets-<cr-name>'  
-          image: quay.io/fedora/postgresql-15:latest
+                name: "{POSTGRESQL_SECRET}"  # will be replaced with 'backstage-psql-secrets-<cr-name>'
+          image: "${RELATED_IMAGE_postgresql}" # defined in operator-bundle CSV as an environment variable"
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true


### PR DESCRIPTION
### What does this PR do?

chore: instead of hardcoding `quay.io/fedora/postgresql-15:latest` in config/manager/default-config/db-statefulset.yaml, extract to an env var RELATED_IMAGE_postgresql = `registry.redhat.io/rhel9/postgresql-15:latest`

Signed-off-by: RHDH Build (rhdh-bot) <rhdh-bot@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://github.com/janus-idp/operator/issues/80
https://issues.redhat.com/browse/RHIDP-488



### How to test this PR?
This is an incomplete solution -- it requires an update to the operator itself to fetch `RELATED_IMAGE_postgresql` and use that inside the [config/manager/default-config/db-statefulset.yaml](https://github.com/janus-idp/operator/pull/83/files#diff-b686120f5593397c2cf57779af726c1c9bd968c2f859c946a89d87d4b7c5e49c)

