### PR TITLE
Move `bundle.Dockerfile` under `docker` directory whenever it gets regenerated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -252,6 +252,7 @@ bundle: manifests kustomize ## Generate bundle manifests and metadata, then vali
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle $(BUNDLE_GEN_FLAGS)
 	operator-sdk bundle validate ./bundle
+	mv -f bundle.Dockerfile docker/bundle.Dockerfile
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.

--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ bundle: manifests kustomize ## Generate bundle manifests and metadata, then vali
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(IMG)
 	$(KUSTOMIZE) build config/manifests | operator-sdk generate bundle $(BUNDLE_GEN_FLAGS)
 	operator-sdk bundle validate ./bundle
-	mv -f bundle.Dockerfile docker/bundle.Dockerfile
+	cat docker/license_header.txt bundle.Dockerfile > docker/bundle.Dockerfile; rm -f bundle.Dockerfile
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
@@ -271,7 +271,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.23.0/$${OS}-$${ARCH}-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/v1.33.0/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else

--- a/docker/bundle.Dockerfile
+++ b/docker/bundle.Dockerfile
@@ -1,14 +1,3 @@
-# Copyright (c) 2023-2024 Red Hat, Inc.
-# This program and the accompanying materials are made
-# available under the terms of the Eclipse Public License 2.0
-# which is available at https://www.eclipse.org/legal/epl-2.0/
-#
-# SPDX-License-Identifier: EPL-2.0
-#
-# Contributors:
-#   Red Hat, Inc. - initial API and implementation
-#
-
 FROM scratch
 
 # Core bundle labels.

--- a/docker/bundle.Dockerfile
+++ b/docker/bundle.Dockerfile
@@ -1,3 +1,13 @@
+# Copyright (c) 2023-2024 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#
 FROM scratch
 
 # Core bundle labels.
@@ -6,7 +16,7 @@ LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=backstage-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.32.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.33.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/docker/license_header.txt
+++ b/docker/license_header.txt
@@ -1,0 +1,10 @@
+# Copyright (c) 2023-2024 Red Hat, Inc.
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#   Red Hat, Inc. - initial API and implementation
+#


### PR DESCRIPTION
## Description
As reported in #84, `bundle.Dockerfile` gets recreated at the root directory whenever `make bundle` is run. This PR just moves the new file to the `docker` directory. Otherwise, it can create confusion if we have both `bundle.Dockerfile` files. Worse, `make bundle-build` might not use the right `bundle.Dockerfile` after a regeneration (since it uses `docker/bundle.Dockerfile` - https://github.com/janus-idp/operator/blob/main/Makefile#L258).

## Which issue(s) does this PR fix or relate to

- Fixes #84 
- Related to #75 

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
`make bundle` should not create a ` bundle.Dockerfile` file at the root directory. It should exist under `docker/` instead.