### PR TITLE
Enable Operator for restricted network environments

### DIFF
--- a/api/v1alpha1/backstage_types.go
+++ b/api/v1alpha1/backstage_types.go
@@ -21,8 +21,8 @@ import (
 const (
 	RuntimeConditionRunning string = "RuntimeRunning"
 	RuntimeConditionSynced  string = "RuntimeSyncedWithConfig"
-	EnvPostGresImage        string = "POSTGRESQL_IMAGE"
-	EnvBackstageImage       string = "BACKSTAGE_IMAGE"
+	EnvPostGresImage        string = "RELATED_IMAGE_postgresql"
+	EnvBackstageImage       string = "RELATED_IMAGE_backstage"
 )
 
 // BackstageSpec defines the desired state of Backstage

--- a/api/v1alpha1/backstage_types.go
+++ b/api/v1alpha1/backstage_types.go
@@ -21,6 +21,8 @@ import (
 const (
 	RuntimeConditionRunning string = "RuntimeRunning"
 	RuntimeConditionSynced  string = "RuntimeSyncedWithConfig"
+	EnvPostGresImage        string = "POSTGRESQL_IMAGE"
+	EnvBackstageImage       string = "BACKSTAGE_IMAGE"
 )
 
 // BackstageSpec defines the desired state of Backstage

--- a/bundle/manifests/backstage-default-config_v1_configmap.yaml
+++ b/bundle/manifests/backstage-default-config_v1_configmap.yaml
@@ -58,8 +58,8 @@ data:
     \           - name: PGDATA\n              value: /var/lib/pgsql/data/userdata\n
     \         envFrom:\n            - secretRef:\n                name: \"{POSTGRESQL_SECRET}\"
     \ # will be replaced with 'backstage-psql-secrets-<cr-name>'  \n          image:
-    quay.io/fedora/postgresql-15:latest\n          imagePullPolicy: IfNotPresent\n
-    \         securityContext:\n            runAsNonRoot: true\n            allowPrivilegeEscalation:
+    \"{POSTGRESQL_IMAGE}\" # will be replaced with the actual image\n          imagePullPolicy:
+    IfNotPresent\n          securityContext:\n            runAsNonRoot: true\n            allowPrivilegeEscalation:
     false\n            seccompProfile:\n              type: RuntimeDefault\n            capabilities:\n
     \             drop:\n                - ALL\n          livenessProbe:\n            exec:\n
     \             command:\n                - /bin/sh\n                - -c\n                -
@@ -95,14 +95,15 @@ data:
     \     initContainers:\n        - command:\n            - ./install-dynamic-plugins.sh\n
     \           - /dynamic-plugins-root\n          env:\n            - name: NPM_CONFIG_USERCONFIG\n
     \             value: /opt/app-root/src/.npmrc.dynamic-plugins\n          image:
-    'quay.io/janus-idp/backstage-showcase:next'\n          imagePullPolicy: IfNotPresent\n
-    \         name: install-dynamic-plugins\n          volumeMounts:\n            -
-    mountPath: /dynamic-plugins-root\n              name: dynamic-plugins-root\n            -
-    mountPath: /opt/app-root/src/.npmrc.dynamic-plugins\n              name: dynamic-plugins-npmrc\n
-    \             readOnly: true\n              subPath: .npmrc\n          workingDir:
-    /opt/app-root/src\n\n      containers:\n        - name: backstage-backend\n          image:
-    quay.io/janus-idp/backstage-showcase:next\n          imagePullPolicy: IfNotPresent\n
-    \         args:\n            - \"--config\"\n            - \"dynamic-plugins-root/app-config.dynamic-plugins.yaml\"\n
+    \"{BACKSTAGE_IMAGE}\" # will be replaced with the actual image quay.io/janus-idp/backstage-showcase:next\n
+    \         imagePullPolicy: IfNotPresent\n          name: install-dynamic-plugins\n
+    \         volumeMounts:\n            - mountPath: /dynamic-plugins-root\n              name:
+    dynamic-plugins-root\n            - mountPath: /opt/app-root/src/.npmrc.dynamic-plugins\n
+    \             name: dynamic-plugins-npmrc\n              readOnly: true\n              subPath:
+    .npmrc\n          workingDir: /opt/app-root/src\n\n      containers:\n        -
+    name: backstage-backend\n          image: \"{BACKSTAGE_IMAGE}\" # will be replaced
+    with the actual image quay.io/janus-idp/backstage-showcase:next\n          imagePullPolicy:
+    IfNotPresent\n          args:\n            - \"--config\"\n            - \"dynamic-plugins-root/app-config.dynamic-plugins.yaml\"\n
     \         readinessProbe:\n            failureThreshold: 3\n            httpGet:\n
     \             path: /healthcheck\n              port: 7007\n              scheme:
     HTTP\n            initialDelaySeconds: 30\n            periodSeconds: 10\n            successThreshold:

--- a/bundle/manifests/backstage-default-config_v1_configmap.yaml
+++ b/bundle/manifests/backstage-default-config_v1_configmap.yaml
@@ -58,7 +58,7 @@ data:
     \           - name: PGDATA\n              value: /var/lib/pgsql/data/userdata\n
     \         envFrom:\n            - secretRef:\n                name: \"{POSTGRESQL_SECRET}\"
     \ # will be replaced with 'backstage-psql-secrets-<cr-name>'  \n          image:
-    \"{POSTGRESQL_IMAGE}\" # will be replaced with the actual image\n          imagePullPolicy:
+    \"{RELATED_IMAGE_postgresql}\" # will be replaced with the actual image\n          imagePullPolicy:
     IfNotPresent\n          securityContext:\n            runAsNonRoot: true\n            allowPrivilegeEscalation:
     false\n            seccompProfile:\n              type: RuntimeDefault\n            capabilities:\n
     \             drop:\n                - ALL\n          livenessProbe:\n            exec:\n
@@ -95,29 +95,29 @@ data:
     \     initContainers:\n        - command:\n            - ./install-dynamic-plugins.sh\n
     \           - /dynamic-plugins-root\n          env:\n            - name: NPM_CONFIG_USERCONFIG\n
     \             value: /opt/app-root/src/.npmrc.dynamic-plugins\n          image:
-    \"{BACKSTAGE_IMAGE}\" # will be replaced with the actual image quay.io/janus-idp/backstage-showcase:next\n
+    \"{RELATED_IMAGE_backstage}\" # will be replaced with the actual image quay.io/janus-idp/backstage-showcase:next\n
     \         imagePullPolicy: IfNotPresent\n          name: install-dynamic-plugins\n
     \         volumeMounts:\n            - mountPath: /dynamic-plugins-root\n              name:
     dynamic-plugins-root\n            - mountPath: /opt/app-root/src/.npmrc.dynamic-plugins\n
     \             name: dynamic-plugins-npmrc\n              readOnly: true\n              subPath:
     .npmrc\n          workingDir: /opt/app-root/src\n\n      containers:\n        -
-    name: backstage-backend\n          image: \"{BACKSTAGE_IMAGE}\" # will be replaced
-    with the actual image quay.io/janus-idp/backstage-showcase:next\n          imagePullPolicy:
-    IfNotPresent\n          args:\n            - \"--config\"\n            - \"dynamic-plugins-root/app-config.dynamic-plugins.yaml\"\n
-    \         readinessProbe:\n            failureThreshold: 3\n            httpGet:\n
+    name: backstage-backend\n          image: \"{RELATED_IMAGE_backstage}\" # will
+    be replaced with the actual image quay.io/janus-idp/backstage-showcase:next\n
+    \         imagePullPolicy: IfNotPresent\n          args:\n            - \"--config\"\n
+    \           - \"dynamic-plugins-root/app-config.dynamic-plugins.yaml\"\n          readinessProbe:\n
+    \           failureThreshold: 3\n            httpGet:\n              path: /healthcheck\n
+    \             port: 7007\n              scheme: HTTP\n            initialDelaySeconds:
+    30\n            periodSeconds: 10\n            successThreshold: 2\n            timeoutSeconds:
+    2\n          livenessProbe:\n            failureThreshold: 3\n            httpGet:\n
     \             path: /healthcheck\n              port: 7007\n              scheme:
-    HTTP\n            initialDelaySeconds: 30\n            periodSeconds: 10\n            successThreshold:
-    2\n            timeoutSeconds: 2\n          livenessProbe:\n            failureThreshold:
-    3\n            httpGet:\n              path: /healthcheck\n              port:
-    7007\n              scheme: HTTP\n            initialDelaySeconds: 60\n            periodSeconds:
-    10\n            successThreshold: 1\n            timeoutSeconds: 2\n          ports:\n
-    \           - name: backend\n              containerPort: 7007\n          env:\n
-    \           - name: APP_CONFIG_backend_listen_port\n              value: \"7007\"\n
-    \         envFrom:\n            - secretRef:\n                name: \"{POSTGRESQL_SECRET}\"
-    \ # will be replaced with 'backstage-psql-secrets-<cr-name>'  \n          #            -
-    secretRef:\n          #                name: backstage-secrets\n          volumeMounts:\n
-    \           - mountPath: /opt/app-root/src/dynamic-plugins-root\n              name:
-    dynamic-plugins-root"
+    HTTP\n            initialDelaySeconds: 60\n            periodSeconds: 10\n            successThreshold:
+    1\n            timeoutSeconds: 2\n          ports:\n            - name: backend\n
+    \             containerPort: 7007\n          env:\n            - name: APP_CONFIG_backend_listen_port\n
+    \             value: \"7007\"\n          envFrom:\n            - secretRef:\n
+    \               name: \"{POSTGRESQL_SECRET}\"  # will be replaced with 'backstage-psql-secrets-<cr-name>'
+    \ \n          #            - secretRef:\n          #                name: backstage-secrets\n
+    \         volumeMounts:\n            - mountPath: /opt/app-root/src/dynamic-plugins-root\n
+    \             name: dynamic-plugins-root"
   dynamic-plugins-configmap.yaml: |-
     apiVersion: v1
     kind: ConfigMap

--- a/bundle/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/backstage-operator.clusterserviceversion.yaml
@@ -21,8 +21,8 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-12-18T21:01:24Z"
-    operators.operatorframework.io/builder: operator-sdk-v1.32.0
+    createdAt: "2023-12-20T02:05:49Z"
+    operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: backstage-operator.v0.0.1
   namespace: placeholder
@@ -164,6 +164,9 @@ spec:
                         operator: In
                         values:
                         - amd64
+                        - arm64
+                        - ppc64le
+                        - s390x
                       - key: kubernetes.io/os
                         operator: In
                         values:
@@ -198,6 +201,11 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
+                env:
+                - name: POSTGRESQL_IMAGE
+                  value: quay.io/fedora/postgresql-15:latest
+                - name: BACKSTAGE_IMAGE
+                  value: quay.io/janus-idp/backstage-showcase:next
                 image: quay.io/rhdh/backstage-operator:v0.0.1
                 livenessProbe:
                   httpGet:

--- a/bundle/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/backstage-operator.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-12-20T02:05:49Z"
+    createdAt: "2023-12-20T13:27:15Z"
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: backstage-operator.v0.0.1
@@ -202,9 +202,9 @@ spec:
                 command:
                 - /manager
                 env:
-                - name: POSTGRESQL_IMAGE
+                - name: RELATED_IMAGE_postgresql
                   value: quay.io/fedora/postgresql-15:latest
-                - name: BACKSTAGE_IMAGE
+                - name: RELATED_IMAGE_backstage
                   value: quay.io/janus-idp/backstage-showcase:next
                 image: quay.io/rhdh/backstage-operator:v0.0.1
                 livenessProbe:
@@ -304,4 +304,9 @@ spec:
   provider:
     name: Red Hat Inc.
     url: https://www.redhat.com/
+  relatedImages:
+  - image: quay.io/fedora/postgresql-15:latest
+    name: postgresql
+  - image: quay.io/janus-idp/backstage-showcase:next
+    name: backstage
   version: 0.0.1

--- a/bundle/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/backstage-operator.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-12-20T13:27:15Z"
+    createdAt: "2023-12-20T15:47:39Z"
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: backstage-operator.v0.0.1

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -5,7 +5,7 @@ annotations:
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: backstage-operator
   operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.32.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.33.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/manager/default-config/db-statefulset.yaml
+++ b/config/manager/default-config/db-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
           envFrom:
             - secretRef:
                 name: "{POSTGRESQL_SECRET}"  # will be replaced with 'backstage-psql-secrets-<cr-name>'  
-          image: quay.io/fedora/postgresql-15:latest
+          image: "{POSTGRESQL_IMAGE}" # will be replaced with the actual image
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true

--- a/config/manager/default-config/db-statefulset.yaml
+++ b/config/manager/default-config/db-statefulset.yaml
@@ -29,7 +29,7 @@ spec:
           envFrom:
             - secretRef:
                 name: "{POSTGRESQL_SECRET}"  # will be replaced with 'backstage-psql-secrets-<cr-name>'  
-          image: "{POSTGRESQL_IMAGE}" # will be replaced with the actual image
+          image: "{RELATED_IMAGE_postgresql}" # will be replaced with the actual image
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true

--- a/config/manager/default-config/deployment.yaml
+++ b/config/manager/default-config/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           env:
             - name: NPM_CONFIG_USERCONFIG
               value: /opt/app-root/src/.npmrc.dynamic-plugins
-          image: "{BACKSTAGE_IMAGE}" # will be replaced with the actual image quay.io/janus-idp/backstage-showcase:next
+          image: "{RELATED_IMAGE_backstage}" # will be replaced with the actual image quay.io/janus-idp/backstage-showcase:next
           imagePullPolicy: IfNotPresent
           name: install-dynamic-plugins
           volumeMounts:
@@ -50,7 +50,7 @@ spec:
 
       containers:
         - name: backstage-backend
-          image: "{BACKSTAGE_IMAGE}" # will be replaced with the actual image quay.io/janus-idp/backstage-showcase:next
+          image: "{RELATED_IMAGE_backstage}" # will be replaced with the actual image quay.io/janus-idp/backstage-showcase:next
           imagePullPolicy: IfNotPresent
           args:
             - "--config"

--- a/config/manager/default-config/deployment.yaml
+++ b/config/manager/default-config/deployment.yaml
@@ -36,7 +36,7 @@ spec:
           env:
             - name: NPM_CONFIG_USERCONFIG
               value: /opt/app-root/src/.npmrc.dynamic-plugins
-          image: 'quay.io/janus-idp/backstage-showcase:next'
+          image: "{BACKSTAGE_IMAGE}" # will be replaced with the actual image quay.io/janus-idp/backstage-showcase:next
           imagePullPolicy: IfNotPresent
           name: install-dynamic-plugins
           volumeMounts:
@@ -50,7 +50,7 @@ spec:
 
       containers:
         - name: backstage-backend
-          image: quay.io/janus-idp/backstage-showcase:next
+          image: "{BACKSTAGE_IMAGE}" # will be replaced with the actual image quay.io/janus-idp/backstage-showcase:next
           imagePullPolicy: IfNotPresent
           args:
             - "--config"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -70,6 +70,11 @@ spec:
         - /manager
         args:
         - --leader-elect
+        env:
+        - name: POSTGRESQL_IMAGE
+          value: quay.io/fedora/postgresql-15:latest
+        - name: BACKSTAGE_IMAGE
+          value: quay.io/janus-idp/backstage-showcase:next
         image: controller:latest
         name: manager
         securityContext:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -71,9 +71,9 @@ spec:
         args:
         - --leader-elect
         env:
-        - name: POSTGRESQL_IMAGE
+        - name: RELATED_IMAGE_postgresql
           value: quay.io/fedora/postgresql-15:latest
-        - name: BACKSTAGE_IMAGE
+        - name: RELATED_IMAGE_backstage
           value: quay.io/janus-idp/backstage-showcase:next
         image: controller:latest
         name: manager

--- a/controllers/backstage_controller.go
+++ b/controllers/backstage_controller.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/go-logr/logr"
 	bs "janus-idp.io/backstage-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -54,6 +55,10 @@ type BackstageReconciler struct {
 	Namespace string
 
 	IsOpenShift bool
+
+	PsqlImage string
+
+	BackstageImage string
 }
 
 //+kubebuilder:rbac:groups=janus-idp.io,resources=backstages,verbs=get;list;watch;create;update;patch;delete
@@ -260,11 +265,18 @@ func (r *BackstageReconciler) labels(meta *v1.ObjectMeta, backstage bs.Backstage
 }
 
 // SetupWithManager sets up the controller with the Manager.
-func (r *BackstageReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *BackstageReconciler) SetupWithManager(mgr ctrl.Manager, log logr.Logger) error {
 
-	//if err := initDefaults(); err != nil {
-	//	return err
-	//}
+	if len(r.PsqlImage) == 0 {
+		r.PsqlImage = "quay.io/fedora/postgresql-15:latest"
+		log.Info("Enviroment variable is not set, default is used", bs.EnvPostGresImage, r.PsqlImage)
+	}
+
+	if len(r.BackstageImage) == 0 {
+		r.BackstageImage = "quay.io/janus-idp/backstage-showcase:next"
+		log.Info("Enviroment variable is not set, default is used", bs.EnvBackstageImage, r.BackstageImage)
+	}
+
 	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&bs.Backstage{})
 

--- a/controllers/backstage_controller_test.go
+++ b/controllers/backstage_controller_test.go
@@ -60,8 +60,8 @@ var _ = Describe("Backstage controller", func() {
 			Scheme:         k8sClient.Scheme(),
 			Namespace:      ns,
 			OwnsRuntime:    true,
-			PsqlImage:      "quay.io/fedora/postgresql-15:latest",
-			BackstageImage: "quay.io/janus-idp/backstage-showcase:next",
+			PsqlImage:      "test-postgresql-15:latest",
+			BackstageImage: "test-backstage-showcase:next",
 		}
 	})
 

--- a/controllers/backstage_controller_test.go
+++ b/controllers/backstage_controller_test.go
@@ -56,10 +56,12 @@ var _ = Describe("Backstage controller", func() {
 		Expect(err).To(Not(HaveOccurred()))
 
 		backstageReconciler = &BackstageReconciler{
-			Client:      k8sClient,
-			Scheme:      k8sClient.Scheme(),
-			Namespace:   ns,
-			OwnsRuntime: true,
+			Client:         k8sClient,
+			Scheme:         k8sClient.Scheme(),
+			Namespace:      ns,
+			OwnsRuntime:    true,
+			PsqlImage:      "quay.io/fedora/postgresql-15:latest",
+			BackstageImage: "quay.io/janus-idp/backstage-showcase:next",
 		}
 	})
 

--- a/controllers/backstage_deployment.go
+++ b/controllers/backstage_deployment.go
@@ -306,14 +306,9 @@ func (r *BackstageReconciler) validateAndUpdatePsqlSecretRef(backstage bs.Backst
 }
 
 func (r *BackstageReconciler) setDefaultDeploymentImage(deployment *appsv1.Deployment) {
-	for i, c := range deployment.Spec.Template.Spec.InitContainers {
-		if len(c.Image) == 0 || c.Image == fmt.Sprintf("{%s}", bs.EnvBackstageImage) {
-			deployment.Spec.Template.Spec.InitContainers[i].Image = r.BackstageImage
+	visitContainers(&deployment.Spec.Template, func(container *v1.Container) {
+		if len(container.Image) == 0 || container.Image == fmt.Sprintf("{%s}", bs.EnvBackstageImage) {
+			container.Image = r.BackstageImage
 		}
-	}
-	for i, c := range deployment.Spec.Template.Spec.Containers {
-		if len(c.Image) == 0 || c.Image == fmt.Sprintf("{%s}", bs.EnvBackstageImage) {
-			deployment.Spec.Template.Spec.Containers[i].Image = r.BackstageImage
-		}
-	}
+	})
 }

--- a/controllers/local_db_statefulset.go
+++ b/controllers/local_db_statefulset.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -217,9 +218,9 @@ func (r *BackstageReconciler) patchLocalDbStatefulSetObj(statefulSet *appsv1.Sta
 }
 
 func (r *BackstageReconciler) setDefaultStatefulSetImage(statefulSet *appsv1.StatefulSet) {
-	for i, c := range statefulSet.Spec.Template.Spec.Containers {
-		if len(c.Image) == 0 || c.Image == fmt.Sprintf("{%s}", bs.EnvPostGresImage) {
-			statefulSet.Spec.Template.Spec.Containers[i].Image = r.PsqlImage
+	visitContainers(&statefulSet.Spec.Template, func(container *v1.Container) {
+		if len(container.Image) == 0 || container.Image == fmt.Sprintf("{%s}", bs.EnvPostGresImage) {
+			container.Image = r.PsqlImage
 		}
-	}
+	})
 }

--- a/main.go
+++ b/main.go
@@ -104,11 +104,13 @@ func main() {
 	}
 
 	if err = (&controller.BackstageReconciler{
-		Client:      mgr.GetClient(),
-		Scheme:      mgr.GetScheme(),
-		OwnsRuntime: ownRuntime,
-		IsOpenShift: isOpenShift,
-	}).SetupWithManager(mgr); err != nil {
+		Client:         mgr.GetClient(),
+		Scheme:         mgr.GetScheme(),
+		OwnsRuntime:    ownRuntime,
+		IsOpenShift:    isOpenShift,
+		PsqlImage:      os.Getenv(backstageiov1alpha1.EnvPostGresImage),
+		BackstageImage: os.Getenv(backstageiov1alpha1.EnvBackstageImage),
+	}).SetupWithManager(mgr, setupLog); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Backstage")
 		os.Exit(1)
 	}
@@ -123,7 +125,13 @@ func main() {
 		os.Exit(1)
 	}
 
-	setupLog.Info("starting manager with parameters: ", "own-runtime", ownRuntime, "env.LOCALBIN", os.Getenv("LOCALBIN"), "isOpenShift", isOpenShift)
+	setupLog.Info("starting manager with parameters: ",
+		"own-runtime", ownRuntime,
+		"env.LOCALBIN", os.Getenv("LOCALBIN"),
+		"isOpenShift", isOpenShift,
+		backstageiov1alpha1.EnvPostGresImage, os.Getenv(backstageiov1alpha1.EnvPostGresImage),
+		backstageiov1alpha1.EnvBackstageImage, os.Getenv(backstageiov1alpha1.EnvBackstageImage),
+	)
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)


### PR DESCRIPTION
## Description
Use environment variables POSTGRESQL_IMAGE and BACKSTAGE_IMAGE to the operator container to indicate the default images used by the operator to deploy psql db and backstage application, respectively. 
Note that: 
a) If the psql db statefulset has image unset, or set to the special string {POSTGRESQL_IMAGE}, the operator will replace it with the value of the environment variable POSTGRESQL_IMAGE. Similarly BACKSTAGE_IMAGE is introdiced for the backstage deployment object.
b) The user can still override the backstage image using the Backstage CR spec.application.image field.

## Which issue(s) does this PR fix or relate to

- Fixes #80 

## PR acceptance criteria

- [X] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
Deploy the operator and the examples CRs. Check that the backstage app and psql db pods are running successfully.
