### PR TITLE
remove unsupported flag --leader-election-id

### DIFF
--- a/.rhdh/bundle/manifests/rhdh-operator.csv.yaml
+++ b/.rhdh/bundle/manifests/rhdh-operator.csv.yaml
@@ -201,7 +201,6 @@ spec:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
                 - --leader-elect
-                - --leader-election-id=rhdh-operator
                 env:
                 - name: OPERATOR_NAME
                   value: rhdh-operator


### PR DESCRIPTION
### What does this PR do?

remove unsupported flag --leader-election-id

Signed-off-by: RHDH Build (rhdh-bot) <rhdh-bot@redhat.com>

### Screenshot/screencast of this PR

![image](https://github.com/janus-idp/operator/assets/227597/2da88017-0dc7-4f68-bda5-66a69073b517)


### What issues does this PR fix or reference?


I'm seeing a problem starting the operator on my clusterbot 4.14 cluster...
```
flag provided but not defined: -leader-election-id
Usage of /manager:
  -health-probe-bind-address string
    	The address the probe endpoint binds to. (default ":8081")
  -kubeconfig string
    	Paths to a kubeconfig. Only required if out-of-cluster.
  -leader-elect
    	Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.
  -metrics-bind-address string
    	The address the metric endpoint binds to. (default ":8080")
  -own-runtime
    	Making Backstage Controller own runtime objects. If 'true' - all runtime objects created by Controller will be syncing with desired state configured by Controller (default true)
...
```

### How to test this PR?

* build a new bundle container in brew/OSBS
* wait until an IIB exists (run the next step until it stops throwing an error)
* copy that to quay using `copyIIBsToQuay.sh -p -t 1.1`
* install with `installCatalogSourceFromIIB.sh --iib quay.io/rhdh/iib:latest-v4.14-x86_64 --install-operator rhdh`

### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.