### PR TITLE
Inject default Backend Auth Key app-config ConfigMap if `spec.application.appConfig.configMaps` is empty

### DIFF
--- a/controllers/backstage_backend_auth.go
+++ b/controllers/backstage_backend_auth.go
@@ -30,8 +30,7 @@ func (r *BackstageReconciler) getBackendAuthAppConfig(
 	backstage bs.Backstage,
 	ns string,
 ) (backendAuthAppConfig *bs.ObjectKeyRef, err error) {
-	if backstage.Spec.Application != nil &&
-		(backstage.Spec.Application.AppConfig != nil || backstage.Spec.Application.ExtraFiles != nil || backstage.Spec.Application.ExtraEnvs != nil) {
+	if hasUserDefinedAppConfig(backstage) {
 		// Users are expected to fill their app-config(s) with their own backend auth key
 		return nil, nil
 	}
@@ -64,4 +63,14 @@ func (r *BackstageReconciler) getBackendAuthAppConfig(
 	}
 
 	return &bs.ObjectKeyRef{Name: backendAuthCmName}, nil
+}
+
+func hasUserDefinedAppConfig(backstage bs.Backstage) bool {
+	if backstage.Spec.Application == nil {
+		return false
+	}
+	if backstage.Spec.Application.AppConfig == nil {
+		return false
+	}
+	return len(backstage.Spec.Application.AppConfig.ConfigMaps) != 0
 }


### PR DESCRIPTION
## Description
This PR relaxes the condition for creating and injecting default app-config ConfigMap storing the default backend auth key for Backstage.
Previously, it would do so only if `spec.application.appConfig` and `spec.application.extraFiles` and `spec.application.extraEnvs` were not set.
Now, we are only checking that the list of user-defined app-configs in `spec.application.appConfig.configMaps` is non-empty.

## Which issue(s) does this PR fix or relate to

&mdash;

## PR acceptance criteria

- [x] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer

Previously, the following CR would not result in a running Backstage container:
```yaml
spec:
  application:
    appConfig:
      mountPath: /opt/app-root/src
    extraFiles:
      mountPath: /opt/app-root/src
    replicas: 1
  database:
    enableLocalDb: true
```

It should work now with the changes here.