### PR TITLE
minKubeVersion should be set in the CSV

### DIFF
--- a/bundle/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/backstage-operator.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-01-09T20:56:26Z"
+    createdAt: "2024-01-12T14:31:03Z"
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: backstage-operator.v0.0.1
@@ -301,6 +301,7 @@ spec:
   - email: jianrzha@redhat.com
     name: Jianrong Zhang
   maturity: alpha
+  minKubeVersion: 1.25.0
   provider:
     name: Red Hat Inc.
     url: https://www.redhat.com/

--- a/config/manifests/bases/backstage-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/backstage-operator.clusterserviceversion.yaml
@@ -47,6 +47,7 @@ spec:
   - email: jianrzha@redhat.com
     name: Jianrong Zhang
   maturity: alpha
+  minKubeVersion: 1.25.0
   provider:
     name: Red Hat Inc.
     url: https://www.redhat.com/


### PR DESCRIPTION
## Description
Set minKuberVersion to 1.25.0 so that the operator can only be deployed on OpenShift 4.12+.

## Which issue(s) does this PR fix or relate to

- Fixes #139 

## PR acceptance criteria

- [ X] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
Check the csv and confirm minKuberVersion is set.
