### PR TITLE
Add error messages to backstage CR status

### DIFF
--- a/api/v1alpha1/backstage_types.go
+++ b/api/v1alpha1/backstage_types.go
@@ -20,14 +20,11 @@ import (
 
 const (
 	//RuntimeConditionRunning string = "RuntimeRunning"
-	ConditionSynced        string = "Synced"
-	ConditionRouteSynced   string = "RouteSynced"
-	ConditionLocalDbSynced string = "LocalDbSynced"
-	SyncOK                 string = "SyncOK"
-	SyncFailed             string = "SyncFailed"
-	Deleted                string = "Deleted"
-	EnvPostGresImage       string = "RELATED_IMAGE_postgresql"
-	EnvBackstageImage      string = "RELATED_IMAGE_backstage"
+	ConditionSynced   string = "Synced"
+	SyncOK            string = "SyncOK"
+	SyncFailed        string = "SyncFailed"
+	EnvPostGresImage  string = "RELATED_IMAGE_postgresql"
+	EnvBackstageImage string = "RELATED_IMAGE_backstage"
 )
 
 // BackstageSpec defines the desired state of Backstage

--- a/api/v1alpha1/backstage_types.go
+++ b/api/v1alpha1/backstage_types.go
@@ -19,15 +19,15 @@ import (
 )
 
 const (
-	RuntimeConditionRunning string = "RuntimeRunning"
-	RuntimeConditionSynced  string = "RuntimeSyncedWithConfig"
-	RouteSynced             string = "RouteSynced"
-	LocalDbSynced           string = "LocalDbSynced"
-	SyncOK                  string = "SyncOK"
-	SyncFailed              string = "SyncFailed"
-	Deleted                 string = "Deleted"
-	EnvPostGresImage        string = "RELATED_IMAGE_postgresql"
-	EnvBackstageImage       string = "RELATED_IMAGE_backstage"
+	//RuntimeConditionRunning string = "RuntimeRunning"
+	ConditionSynced        string = "Synced"
+	ConditionRouteSynced   string = "RouteSynced"
+	ConditionLocalDbSynced string = "LocalDbSynced"
+	SyncOK                 string = "SyncOK"
+	SyncFailed             string = "SyncFailed"
+	Deleted                string = "Deleted"
+	EnvPostGresImage       string = "RELATED_IMAGE_postgresql"
+	EnvBackstageImage      string = "RELATED_IMAGE_backstage"
 )
 
 // BackstageSpec defines the desired state of Backstage

--- a/api/v1alpha1/backstage_types.go
+++ b/api/v1alpha1/backstage_types.go
@@ -18,11 +18,16 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// Constants for status conditions
 const (
-	//RuntimeConditionRunning string = "RuntimeRunning"
-	ConditionSynced   string = "Synced"
-	SyncOK            string = "SyncOK"
-	SyncFailed        string = "SyncFailed"
+	// TODO: RuntimeConditionRunning string = "RuntimeRunning"
+	ConditionSynced string = "Synced"
+	SyncOK          string = "SyncOK"
+	SyncFailed      string = "SyncFailed"
+)
+
+// Constants for image placeholders
+const (
 	EnvPostGresImage  string = "RELATED_IMAGE_postgresql"
 	EnvBackstageImage string = "RELATED_IMAGE_backstage"
 )

--- a/api/v1alpha1/backstage_types.go
+++ b/api/v1alpha1/backstage_types.go
@@ -21,10 +21,10 @@ import (
 // Constants for status conditions
 const (
 	// TODO: RuntimeConditionRunning string = "RuntimeRunning"
-	ConditionSynced string = "Synced"
-	SyncOK          string = "SyncOK"
-	SyncFailed      string = "SyncFailed"
-	SyncInProgress  string = "SyncInProgress"
+	ConditionDeployed string = "Deployed"
+	DeployOK          string = "DeployOK"
+	DeployFailed      string = "DeployFailed"
+	DeployInProgress  string = "DeployInProgress"
 )
 
 // Constants for image placeholders

--- a/api/v1alpha1/backstage_types.go
+++ b/api/v1alpha1/backstage_types.go
@@ -24,6 +24,7 @@ const (
 	ConditionSynced string = "Synced"
 	SyncOK          string = "SyncOK"
 	SyncFailed      string = "SyncFailed"
+	SyncInProgress  string = "SyncInProgress"
 )
 
 // Constants for image placeholders

--- a/bundle/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/backstage-operator.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-01-12T14:31:03Z"
+    createdAt: "2024-01-16T15:47:10Z"
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: backstage-operator.v0.0.1

--- a/bundle/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/backstage-operator.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2024-01-16T15:47:10Z"
+    createdAt: "2024-01-19T01:12:25Z"
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: backstage-operator.v0.0.1

--- a/controllers/backstage_controller.go
+++ b/controllers/backstage_controller.go
@@ -119,33 +119,31 @@ func (r *BackstageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 		*/
 
-		err := r.reconcileLocalDbStatefulSet(ctx, backstage, req.Namespace)
+		err := r.reconcileLocalDbStatefulSet(ctx, &backstage, req.Namespace)
 		if err != nil {
-			setStatusCondition(&backstage, bs.LocalDbSynced, v1.ConditionFalse, bs.SyncFailed, fmt.Sprintf("failed to sync Database StatefulSet:%s", err.Error()))
-			return ctrl.Result{}, fmt.Errorf("failed to sync Database StatefulSet: %w", err)
+			return ctrl.Result{}, err
 		}
 
-		err = r.reconcileLocalDbServices(ctx, backstage, req.Namespace)
+		err = r.reconcileLocalDbServices(ctx, &backstage, req.Namespace)
 		if err != nil {
-			setStatusCondition(&backstage, bs.LocalDbSynced, v1.ConditionFalse, bs.SyncFailed, fmt.Sprintf("failed to sync Database Services:%s", err.Error()))
-			return ctrl.Result{}, fmt.Errorf("failed to sync Database Service: %w", err)
+			return ctrl.Result{}, err
 		}
-		setStatusCondition(&backstage, bs.LocalDbSynced, v1.ConditionTrue, bs.SyncOK, "")
+		setStatusCondition(&backstage, bs.ConditionLocalDbSynced, v1.ConditionTrue, bs.SyncOK, "")
 	} else { // Clean up the deployed local db resources if any
 		if err := r.cleanupLocalDbResources(ctx, backstage); err != nil {
-			setStatusCondition(&backstage, bs.LocalDbSynced, v1.ConditionFalse, bs.SyncFailed, fmt.Sprintf("failed to delete Database Services:%s", err.Error()))
+			setStatusCondition(&backstage, bs.ConditionLocalDbSynced, v1.ConditionFalse, bs.SyncFailed, fmt.Sprintf("failed to delete Database Services:%s", err.Error()))
 			return ctrl.Result{}, fmt.Errorf("failed to delete Database Service: %w", err)
 		}
-		setStatusCondition(&backstage, bs.LocalDbSynced, v1.ConditionTrue, bs.Deleted, "")
+		setStatusCondition(&backstage, bs.ConditionLocalDbSynced, v1.ConditionTrue, bs.Deleted, "")
 	}
 
-	err := r.reconcileBackstageDeployment(ctx, backstage, req.Namespace)
+	err := r.reconcileBackstageDeployment(ctx, &backstage, req.Namespace)
 	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to reconcile Backstage Deployment: %w", err)
+		return ctrl.Result{}, err
 	}
 
-	if err := r.reconcileBackstageService(ctx, backstage, req.Namespace); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to reconcile Backstage Service: %w", err)
+	if err := r.reconcileBackstageService(ctx, &backstage, req.Namespace); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	if r.IsOpenShift {
@@ -154,10 +152,7 @@ func (r *BackstageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}
 
-	//TODO: it is just a placeholder for the time
-	r.setRunningStatus(ctx, &backstage, req.Namespace)
-	r.setSyncStatus(&backstage)
-
+	setStatusCondition(&backstage, bs.ConditionSynced, v1.ConditionTrue, bs.SyncOK, "")
 	return ctrl.Result{}, nil
 }
 
@@ -219,7 +214,8 @@ func defFile(key string) string {
 	return filepath.Join(os.Getenv("LOCALBIN"), "default-config", key)
 }
 
-// sets the RuntimeRunning condition
+/* TODO
+sets the RuntimeRunning condition
 func (r *BackstageReconciler) setRunningStatus(ctx context.Context, backstage *bs.Backstage, ns string) {
 
 	meta.SetStatusCondition(&backstage.Status.Conditions, v1.Condition{
@@ -230,27 +226,7 @@ func (r *BackstageReconciler) setRunningStatus(ctx context.Context, backstage *b
 		Message:            "Runtime in unknown status",
 	})
 }
-
-// sets the RuntimeSyncedWithConfig condition
-func (r *BackstageReconciler) setSyncStatus(backstage *bs.Backstage) {
-
-	status := v1.ConditionUnknown
-	reason := "Unknown"
-	message := "Sync in unknown status"
-	if r.OwnsRuntime {
-		status = v1.ConditionTrue
-		reason = "Synced"
-		message = "Backstage syncs runtime"
-	}
-
-	meta.SetStatusCondition(&backstage.Status.Conditions, v1.Condition{
-		Type:               bs.RuntimeConditionSynced,
-		Status:             status,
-		LastTransitionTime: v1.Time{},
-		Reason:             reason,
-		Message:            message,
-	})
-}
+*/
 
 // sets status condition
 func setStatusCondition(backstage *bs.Backstage, condType string, status v1.ConditionStatus, reason, msg string) {

--- a/controllers/backstage_controller.go
+++ b/controllers/backstage_controller.go
@@ -110,6 +110,10 @@ func (r *BackstageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 	}(&backstage)
 
+	if len(backstage.Status.Conditions) == 0 {
+		setStatusCondition(&backstage, bs.ConditionSynced, v1.ConditionFalse, bs.SyncInProgress, "Reconciliation started")
+	}
+
 	if pointer.BoolDeref(backstage.Spec.Database.EnableLocalDb, true) {
 
 		/* We use default strogeclass currently, and no PV is needed in that case.

--- a/controllers/backstage_controller.go
+++ b/controllers/backstage_controller.go
@@ -128,13 +128,11 @@ func (r *BackstageReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		setStatusCondition(&backstage, bs.ConditionLocalDbSynced, v1.ConditionTrue, bs.SyncOK, "")
 	} else { // Clean up the deployed local db resources if any
 		if err := r.cleanupLocalDbResources(ctx, backstage); err != nil {
-			setStatusCondition(&backstage, bs.ConditionLocalDbSynced, v1.ConditionFalse, bs.SyncFailed, fmt.Sprintf("failed to delete Database Services:%s", err.Error()))
+			setStatusCondition(&backstage, bs.ConditionSynced, v1.ConditionFalse, bs.SyncFailed, fmt.Sprintf("failed to delete Database Services:%s", err.Error()))
 			return ctrl.Result{}, fmt.Errorf("failed to delete Database Service: %w", err)
 		}
-		setStatusCondition(&backstage, bs.ConditionLocalDbSynced, v1.ConditionTrue, bs.Deleted, "")
 	}
 
 	err := r.reconcileBackstageDeployment(ctx, &backstage, req.Namespace)

--- a/controllers/backstage_controller_test.go
+++ b/controllers/backstage_controller_test.go
@@ -371,14 +371,6 @@ var _ = Describe("Backstage controller", func() {
 			By("Checking the latest Status added to the Backstage instance")
 			verifyBackstageInstance(ctx)
 
-			By("Checking the localDb Sync Status in the Backstage instance")
-			Eventually(func(g Gomega) {
-				var backstage bsv1alpha1.Backstage
-				err := k8sClient.Get(ctx, types.NamespacedName{Name: backstageName, Namespace: ns}, &backstage)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(isLocalDbDeployed(backstage)).To(BeTrue())
-			}, time.Minute, time.Second).Should(Succeed())
-
 			By("Checking the localdb statefulset has been created")
 			Eventually(func(g Gomega) {
 				err := k8sClient.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("backstage-psql-%s", backstageName), Namespace: ns}, &appsv1.StatefulSet{})
@@ -416,14 +408,6 @@ var _ = Describe("Backstage controller", func() {
 				NamespacedName: types.NamespacedName{Name: backstageName, Namespace: ns},
 			})
 			Expect(err).To(Not(HaveOccurred()))
-
-			By("Checking the localDb Sync Status has been updated in the Backstage instance")
-			Eventually(func(g Gomega) {
-				var backstage bsv1alpha1.Backstage
-				err := k8sClient.Get(ctx, types.NamespacedName{Name: backstageName, Namespace: ns}, &backstage)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(isLocalDbDeployed(backstage)).To(BeFalse())
-			}, time.Minute, time.Second).Should(Succeed())
 
 			By("Checking that the local db statefulset has been deleted")
 			Eventually(func(g Gomega) {
@@ -1556,13 +1540,6 @@ func findElementsByPredicate[T any](l []T, predicate func(t T) bool) (result []T
 		}
 	}
 	return result
-}
-
-func isLocalDbDeployed(backstage bsv1alpha1.Backstage) bool {
-	if cond := meta.FindStatusCondition(backstage.Status.Conditions, bsv1alpha1.ConditionLocalDbSynced); cond != nil {
-		return cond.Status == metav1.ConditionTrue && cond.Reason == bsv1alpha1.SyncOK
-	}
-	return false
 }
 
 func isSynced(backstage bsv1alpha1.Backstage) bool {

--- a/controllers/backstage_controller_test.go
+++ b/controllers/backstage_controller_test.go
@@ -125,7 +125,7 @@ var _ = Describe("Backstage controller", func() {
 			var backstage bsv1alpha1.Backstage
 			err := k8sClient.Get(ctx, types.NamespacedName{Name: backstageName, Namespace: ns}, &backstage)
 			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(isSynced(backstage)).To(BeTrue())
+			g.Expect(isDeployed(backstage)).To(BeTrue())
 		}, time.Minute, time.Second).Should(Succeed())
 	}
 
@@ -134,10 +134,10 @@ var _ = Describe("Backstage controller", func() {
 			var backstage bsv1alpha1.Backstage
 			err := k8sClient.Get(ctx, types.NamespacedName{Name: backstageName, Namespace: ns}, &backstage)
 			g.Expect(err).NotTo(HaveOccurred())
-			cond := meta.FindStatusCondition(backstage.Status.Conditions, bsv1alpha1.ConditionSynced)
+			cond := meta.FindStatusCondition(backstage.Status.Conditions, bsv1alpha1.ConditionDeployed)
 			g.Expect(cond).NotTo(BeNil())
 			g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
-			g.Expect(cond.Reason).To(Equal(bsv1alpha1.SyncFailed))
+			g.Expect(cond.Reason).To(Equal(bsv1alpha1.DeployFailed))
 			g.Expect(cond.Message).To(ContainSubstring(errMsg))
 		}, time.Minute, time.Second).Should(Succeed())
 	}
@@ -1527,8 +1527,8 @@ func findElementsByPredicate[T any](l []T, predicate func(t T) bool) (result []T
 	return result
 }
 
-func isSynced(backstage bsv1alpha1.Backstage) bool {
-	if cond := meta.FindStatusCondition(backstage.Status.Conditions, bsv1alpha1.ConditionSynced); cond != nil {
+func isDeployed(backstage bsv1alpha1.Backstage) bool {
+	if cond := meta.FindStatusCondition(backstage.Status.Conditions, bsv1alpha1.ConditionDeployed); cond != nil {
 		return cond.Status == metav1.ConditionTrue
 	}
 	return false

--- a/controllers/backstage_deployment.go
+++ b/controllers/backstage_deployment.go
@@ -153,10 +153,10 @@ func (r *BackstageReconciler) reconcileBackstageDeployment(ctx context.Context, 
 	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, deployment, r.deploymentObjectMutFun(ctx, deployment, *backstage, ns)); err != nil {
 		if errors.IsConflict(err) {
-			return fmt.Errorf("retry sync needed: %v", err)
+			return retryReconciliation(err)
 		}
-		msg := fmt.Sprintf("failed to sync Backstage Deployment: %s", err)
-		setStatusCondition(backstage, bs.ConditionSynced, metav1.ConditionFalse, bs.SyncFailed, msg)
+		msg := fmt.Sprintf("failed to deploy Backstage Deployment: %s", err)
+		setStatusCondition(backstage, bs.ConditionDeployed, metav1.ConditionFalse, bs.DeployFailed, msg)
 		return fmt.Errorf(msg)
 	}
 	return nil

--- a/controllers/backstage_deployment.go
+++ b/controllers/backstage_deployment.go
@@ -146,16 +146,18 @@ func visitContainers(podTemplateSpec *v1.PodTemplateSpec, visitor ContainerVisit
 	}
 }
 
-func (r *BackstageReconciler) reconcileBackstageDeployment(ctx context.Context, backstage bs.Backstage, ns string) error {
+func (r *BackstageReconciler) reconcileBackstageDeployment(ctx context.Context, backstage *bs.Backstage, ns string) error {
 	deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{
-		Name:      getDefaultObjName(backstage),
+		Name:      getDefaultObjName(*backstage),
 		Namespace: ns},
 	}
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, deployment, r.deploymentObjectMutFun(ctx, deployment, backstage, ns)); err != nil {
+	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, deployment, r.deploymentObjectMutFun(ctx, deployment, *backstage, ns)); err != nil {
 		if errors.IsConflict(err) {
 			return fmt.Errorf("retry sync needed: %v", err)
 		}
-		return err
+		msg := fmt.Sprintf("failed to sync Backstage Deployment: %s", err.Error())
+		setStatusCondition(backstage, bs.ConditionSynced, metav1.ConditionFalse, bs.SyncFailed, msg)
+		return fmt.Errorf(msg)
 	}
 	return nil
 }

--- a/controllers/backstage_deployment.go
+++ b/controllers/backstage_deployment.go
@@ -155,7 +155,7 @@ func (r *BackstageReconciler) reconcileBackstageDeployment(ctx context.Context, 
 		if errors.IsConflict(err) {
 			return fmt.Errorf("retry sync needed: %v", err)
 		}
-		msg := fmt.Sprintf("failed to sync Backstage Deployment: %s", err.Error())
+		msg := fmt.Sprintf("failed to sync Backstage Deployment: %s", err)
 		setStatusCondition(backstage, bs.ConditionSynced, metav1.ConditionFalse, bs.SyncFailed, msg)
 		return fmt.Errorf(msg)
 	}

--- a/controllers/backstage_route.go
+++ b/controllers/backstage_route.go
@@ -40,7 +40,7 @@ func (r *BackstageReconciler) reconcileBackstageRoute(ctx context.Context, backs
 	if !shouldCreateRoute(*backstage) {
 		_, err := r.cleanupResource(ctx, route, *backstage)
 		if err != nil {
-			setStatusCondition(backstage, bs.ConditionSynced, metav1.ConditionFalse, bs.SyncFailed, fmt.Sprintf("failed to delete route: %s", err))
+			setStatusCondition(backstage, bs.ConditionDeployed, metav1.ConditionFalse, bs.DeployFailed, fmt.Sprintf("failed to delete route: %s", err))
 			return err
 		}
 		return nil
@@ -48,10 +48,10 @@ func (r *BackstageReconciler) reconcileBackstageRoute(ctx context.Context, backs
 
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, route, r.routeObjectMutFun(ctx, route, *backstage, ns)); err != nil {
 		if errors.IsConflict(err) {
-			return fmt.Errorf("retry sync needed: %v", err)
+			return retryReconciliation(err)
 		}
-		msg := fmt.Sprintf("failed to sync Backstage Route: %s", err)
-		setStatusCondition(backstage, bs.ConditionSynced, metav1.ConditionFalse, bs.SyncFailed, msg)
+		msg := fmt.Sprintf("failed to deploy Backstage Route: %s", err)
+		setStatusCondition(backstage, bs.ConditionDeployed, metav1.ConditionFalse, bs.DeployFailed, msg)
 		return fmt.Errorf(msg)
 	}
 	return nil

--- a/controllers/backstage_service.go
+++ b/controllers/backstage_service.go
@@ -38,7 +38,7 @@ func (r *BackstageReconciler) reconcileBackstageService(ctx context.Context, bac
 		if errors.IsConflict(err) {
 			return fmt.Errorf("retry sync needed: %v", err)
 		}
-		msg := fmt.Sprintf("failed to sync Backstage Service: %s", err.Error())
+		msg := fmt.Sprintf("failed to sync Backstage Service: %s", err)
 		setStatusCondition(backstage, bs.ConditionSynced, metav1.ConditionFalse, bs.SyncFailed, msg)
 	}
 	return nil

--- a/controllers/backstage_service.go
+++ b/controllers/backstage_service.go
@@ -26,19 +26,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (r *BackstageReconciler) reconcileBackstageService(ctx context.Context, backstage bs.Backstage, ns string) error {
+func (r *BackstageReconciler) reconcileBackstageService(ctx context.Context, backstage *bs.Backstage, ns string) error {
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      getDefaultObjName(backstage),
+			Name:      getDefaultObjName(*backstage),
 			Namespace: ns,
 		},
 	}
-	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, service, r.serviceObjectMutFun(ctx, service, backstage,
+	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, service, r.serviceObjectMutFun(ctx, service, *backstage,
 		backstage.Spec.RawRuntimeConfig.BackstageConfigName, "service.yaml", service.Name, service.Name)); err != nil {
 		if errors.IsConflict(err) {
 			return fmt.Errorf("retry sync needed: %v", err)
 		}
-		return err
+		msg := fmt.Sprintf("failed to sync Backstage Service: %s", err.Error())
+		setStatusCondition(backstage, bs.ConditionSynced, metav1.ConditionFalse, bs.SyncFailed, msg)
 	}
 	return nil
 }

--- a/controllers/backstage_service.go
+++ b/controllers/backstage_service.go
@@ -36,10 +36,10 @@ func (r *BackstageReconciler) reconcileBackstageService(ctx context.Context, bac
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, service, r.serviceObjectMutFun(ctx, service, *backstage,
 		backstage.Spec.RawRuntimeConfig.BackstageConfigName, "service.yaml", service.Name, service.Name)); err != nil {
 		if errors.IsConflict(err) {
-			return fmt.Errorf("retry sync needed: %v", err)
+			return retryReconciliation(err)
 		}
-		msg := fmt.Sprintf("failed to sync Backstage Service: %s", err)
-		setStatusCondition(backstage, bs.ConditionSynced, metav1.ConditionFalse, bs.SyncFailed, msg)
+		msg := fmt.Sprintf("failed to deploy Backstage Service: %s", err)
+		setStatusCondition(backstage, bs.ConditionDeployed, metav1.ConditionFalse, bs.DeployFailed, msg)
 	}
 	return nil
 }

--- a/controllers/local_db_services.go
+++ b/controllers/local_db_services.go
@@ -85,7 +85,7 @@ func (r *BackstageReconciler) reconcilePsqlService(ctx context.Context, backstag
 		}
 		msg := fmt.Sprintf("failed to sync database service: %s", err.Error())
 		setStatusCondition(backstage, bs.ConditionSynced, metav1.ConditionFalse, bs.SyncFailed, msg)
-		setStatusCondition(backstage, bs.ConditionLocalDbSynced, metav1.ConditionFalse, bs.SyncFailed, msg)
+		setStatusCondition(backstage, bs.ConditionLocalDbSynced, metav1.ConditionFalse, bs.SyncFailed, "local db service sync failed")
 	}
 	return nil
 }

--- a/controllers/local_db_services.go
+++ b/controllers/local_db_services.go
@@ -81,10 +81,10 @@ func (r *BackstageReconciler) reconcilePsqlService(ctx context.Context, backstag
 	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, service, r.serviceObjectMutFun(ctx, service, *backstage, backstage.Spec.RawRuntimeConfig.LocalDbConfigName, configKey, serviceName, label)); err != nil {
 		if errors.IsConflict(err) {
-			return fmt.Errorf("retry sync needed: %v", err)
+			return retryReconciliation(err)
 		}
-		msg := fmt.Sprintf("failed to sync database service: %s", err)
-		setStatusCondition(backstage, bs.ConditionSynced, metav1.ConditionFalse, bs.SyncFailed, msg)
+		msg := fmt.Sprintf("failed to deploy database service: %s", err)
+		setStatusCondition(backstage, bs.ConditionDeployed, metav1.ConditionFalse, bs.DeployFailed, msg)
 	}
 	return nil
 }

--- a/controllers/local_db_services.go
+++ b/controllers/local_db_services.go
@@ -83,9 +83,8 @@ func (r *BackstageReconciler) reconcilePsqlService(ctx context.Context, backstag
 		if errors.IsConflict(err) {
 			return fmt.Errorf("retry sync needed: %v", err)
 		}
-		msg := fmt.Sprintf("failed to sync database service: %s", err.Error())
+		msg := fmt.Sprintf("failed to sync database service: %s", err)
 		setStatusCondition(backstage, bs.ConditionSynced, metav1.ConditionFalse, bs.SyncFailed, msg)
-		setStatusCondition(backstage, bs.ConditionLocalDbSynced, metav1.ConditionFalse, bs.SyncFailed, "local db service sync failed")
 	}
 	return nil
 }

--- a/controllers/local_db_statefulset.go
+++ b/controllers/local_db_statefulset.go
@@ -146,10 +146,10 @@ func (r *BackstageReconciler) reconcileLocalDbStatefulSet(ctx context.Context, b
 	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, r.Client, statefulSet, r.localDBStatefulSetMutFun(ctx, statefulSet, *backstage, ns)); err != nil {
 		if errors.IsConflict(err) {
-			return fmt.Errorf("retry sync needed: %v", err)
+			return retryReconciliation(err)
 		}
-		msg := fmt.Sprintf("failed to sync Database StatefulSet: %s", err)
-		setStatusCondition(backstage, bs.ConditionSynced, metav1.ConditionFalse, bs.SyncFailed, msg)
+		msg := fmt.Sprintf("failed to deploy Database StatefulSet: %s", err)
+		setStatusCondition(backstage, bs.ConditionDeployed, metav1.ConditionFalse, bs.DeployFailed, msg)
 		return fmt.Errorf(msg)
 	}
 	return nil

--- a/controllers/local_db_statefulset.go
+++ b/controllers/local_db_statefulset.go
@@ -148,9 +148,8 @@ func (r *BackstageReconciler) reconcileLocalDbStatefulSet(ctx context.Context, b
 		if errors.IsConflict(err) {
 			return fmt.Errorf("retry sync needed: %v", err)
 		}
-		msg := fmt.Sprintf("failed to sync Database StatefulSet: %s", err.Error())
+		msg := fmt.Sprintf("failed to sync Database StatefulSet: %s", err)
 		setStatusCondition(backstage, bs.ConditionSynced, metav1.ConditionFalse, bs.SyncFailed, msg)
-		setStatusCondition(backstage, bs.ConditionLocalDbSynced, metav1.ConditionFalse, bs.SyncFailed, "local db statefulset sync failed")
 		return fmt.Errorf(msg)
 	}
 	return nil
@@ -235,7 +234,7 @@ func (r *BackstageReconciler) cleanupLocalDbResources(ctx context.Context, backs
 		},
 	}
 	if _, err := r.cleanupResource(ctx, statefulSet, backstage); err != nil {
-		return err
+		return fmt.Errorf("failed to delete database statefulset, reason: %s", err)
 	}
 
 	service := &v1.Service{
@@ -245,9 +244,8 @@ func (r *BackstageReconciler) cleanupLocalDbResources(ctx context.Context, backs
 		},
 	}
 	if _, err := r.cleanupResource(ctx, service, backstage); err != nil {
-		return err
+		return fmt.Errorf("failed to delete database service, reason: %s", err)
 	}
-
 	serviceHL := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("backstage-psql-%s-hl", backstage.Name),
@@ -255,7 +253,7 @@ func (r *BackstageReconciler) cleanupLocalDbResources(ctx context.Context, backs
 		},
 	}
 	if _, err := r.cleanupResource(ctx, serviceHL, backstage); err != nil {
-		return err
+		return fmt.Errorf("failed to delete headless database service, reason: %s", err)
 	}
 
 	secret := &v1.Secret{
@@ -265,7 +263,7 @@ func (r *BackstageReconciler) cleanupLocalDbResources(ctx context.Context, backs
 		},
 	}
 	if _, err := r.cleanupResource(ctx, secret, backstage); err != nil {
-		return err
+		return fmt.Errorf("failed to delete generated database secret, reason: %s", err)
 	}
 	return nil
 }

--- a/controllers/local_db_statefulset.go
+++ b/controllers/local_db_statefulset.go
@@ -150,7 +150,7 @@ func (r *BackstageReconciler) reconcileLocalDbStatefulSet(ctx context.Context, b
 		}
 		msg := fmt.Sprintf("failed to sync Database StatefulSet: %s", err.Error())
 		setStatusCondition(backstage, bs.ConditionSynced, metav1.ConditionFalse, bs.SyncFailed, msg)
-		setStatusCondition(backstage, bs.ConditionLocalDbSynced, metav1.ConditionFalse, bs.SyncFailed, msg)
+		setStatusCondition(backstage, bs.ConditionLocalDbSynced, metav1.ConditionFalse, bs.SyncFailed, "local db statefulset sync failed")
 		return fmt.Errorf(msg)
 	}
 	return nil


### PR DESCRIPTION
## Description
When the operator fails to reconcile a CR, it should present an error in the CR's status for troubleshooting. 
When a CR has been successfully, the CR status should indicate that the deployment process is complete.

Simplified CR status conditions to use Deployed only.

Note that the running status support needs more investigation (on the possible impact on performance) and will be postponed to a future CR.

## Which issue(s) does this PR fix or relate to

- Fixes #71 (partially)

## PR acceptance criteria

- [ X] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
Deploy example/bs1.yaml and the follow CR status should be displayed indicating sync completion.
```
status:
  conditions:
  - lastTransitionTime: "2024-01-23T15:06:21Z"
    message: ""
    reason: DeployOK
    status: "True"
    type: Deployed
``` 

Now update the CR, set application replicas to -1 and then apply the CR change:
```
apiVersion: janus-idp.io/v1alpha1
kind: Backstage
metadata:
  name: bs1
spec:
  application:
    replicas: -1
``` 
You should see the CR status like below:
```
status:
  conditions:
  - lastTransitionTime: "2024-01-23T15:08:24Z"
    message: 'failed to deploy Backstage Deployment: Deployment.apps "backstage-bs1"
      is invalid: spec.replicas: Invalid value: -1: must be greater than or equal
      to 0'
    reason: DeployFailed
    status: "False"
    type: Deployed
``` 

Now if you revert the CR to the default:
```
apiVersion: janus-idp.io/v1alpha1
kind: Backstage
metadata:
  name: bs1
spec:
``` 
You should see DeployOK again:
```
status:
  conditions:
  - lastTransitionTime: "2024-01-23T15:09:06Z"
    message: ""
    reason: DeployOK
    status: "True"
    type: Deployed
``` 
