### PR TITLE
Do not try to build the container images when PR is closed

### DIFF
--- a/.github/workflows/pr-container-build.yaml
+++ b/.github/workflows/pr-container-build.yaml
@@ -21,7 +21,7 @@ on:
   # we are adding an 'authorize' job that checks if the workflow was triggered from a fork PR. In that case, the "external" environment
   # will prevent the job from running until it's approved manually by human intervention.
   pull_request_target:
-    types: [opened, synchronize, reopened, ready_for_review, closed]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ main ]
 
 concurrency:


### PR DESCRIPTION
## Description
At the time [this job](https://github.com/janus-idp/operator/blob/main/.github/workflows/pr-container-build.yaml) runs, the branch might have been deleted already, causing unnecessary failures (+notifications for the PR owner) [1].
Error message seen on a lot of different PRs:
```
A branch or tag with the name '$branch_name' could not be found
```
[1] https://github.com/janus-idp/operator/actions/workflows/pr-container-build.yaml?query=event%3Apull_request_target+is%3Afailure

## Which issue(s) does this PR fix or relate to
&mdash;

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
This job should no longer run when a PR is closed.