### PR TITLE
Do not fallback to a default hard-coded password for PostgreSQL if generation fails

### DIFF
--- a/controllers/local_db_secret.go
+++ b/controllers/local_db_secret.go
@@ -16,14 +16,13 @@ package controller
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/base64"
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	k8srand "k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	bs "janus-idp.io/backstage-operator/api/v1alpha1"
@@ -55,10 +54,7 @@ func (r *BackstageReconciler) handlePsqlSecret(ctx context.Context, statefulSet 
 			return nil, fmt.Errorf("failed to get secret for PostgreSQL DB (%q), reason: %s", secretName, err)
 		}
 		// Create a secret with a random value
-		pwd, pwdErr := generatePassword(24)
-		if pwdErr != nil {
-			return nil, fmt.Errorf("failed to generate a password for the PostgreSQL database: %w", pwdErr)
-		}
+		pwd := k8srand.String(24)
 		sec.StringData["POSTGRES_PASSWORD"] = pwd
 		sec.StringData["POSTGRESQL_ADMIN_PASSWORD"] = pwd
 		sec.StringData["POSTGRES_HOST"] = getDefaultDbObjName(*backstage)
@@ -80,15 +76,6 @@ func (r *BackstageReconciler) handlePsqlSecret(ctx context.Context, statefulSet 
 
 func getDefaultPsqlSecretName(backstage *bs.Backstage) string {
 	return fmt.Sprintf("backstage-psql-secret-%s", backstage.Name)
-}
-
-func generatePassword(length int) (string, error) {
-	bytes := make([]byte, length)
-	if _, err := rand.Read(bytes); err != nil {
-		return "", err
-	}
-	// Encode the password to prevent special characters
-	return base64.StdEncoding.EncodeToString(bytes), nil
 }
 
 func getSecretNameForGeneration(statefulSet *appsv1.StatefulSet, backstage *bs.Backstage) string {

--- a/controllers/local_db_secret.go
+++ b/controllers/local_db_secret.go
@@ -1,18 +1,17 @@
-/*
-Copyright 2023.
+//
+// Copyright (c) 2023 Red Hat, Inc.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-	http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
 package controller
 
 import (


### PR DESCRIPTION
## Description

This has been flagged as a potential security issue, which we should avoid doing.

https://github.com/janus-idp/operator/issues/151 will make sure to enforce such checks and detect such issues earlier as we move forward.

cc @kim-tsao 

## Which issue(s) does this PR fix or relate to
&mdash;

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
`kubectl apply -f examples/bs1.yaml` should result in a working Backstage instance.