### PR TITLE
Fix sonarlint vulnerabilities (initial)

### DIFF
--- a/.rhdh/docker/Dockerfile
+++ b/.rhdh/docker/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 #@follow_tag(registry.redhat.io/rhel9/go-toolset:latest)
-FROM registry.access.redhat.com/ubi9/go-toolset:1.20.10-6 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.20.10-6 AS builder
 # hadolint ignore=DL3002
 USER 0
 ENV GOPATH=/go/

--- a/config/manager/default-config/db-statefulset.yaml
+++ b/config/manager/default-config/db-statefulset.yaml
@@ -15,9 +15,13 @@ spec:
         janus-idp.io/app: backstage-psql-cr1 # placeholder for 'backstage-psql-<cr-name>'
       name: backstage-db-cr1 # placeholder for 'backstage-psql-<cr-name>'
     spec:
-      persistentVolumeClaimRetentionPolicy:
-        whenDeleted: Retain
-        whenScaled: Retain
+      automountServiceAccountToken: false
+      ## https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/
+      ## The optional .spec.persistentVolumeClaimRetentionPolicy field controls if and how PVCs are deleted during the lifecycle of a StatefulSet.
+      ## You must enable the StatefulSetAutoDeletePVC feature gate on the API server and the controller manager to use this field.
+#      persistentVolumeClaimRetentionPolicy:
+#        whenDeleted: Retain
+#        whenScaled: Retain
       containers:
         - env:
             - name: POSTGRESQL_PORT_NUMBER
@@ -73,7 +77,9 @@ spec:
               cpu: 250m
               memory: 256Mi
             limits:
+              cpu: 250m
               memory: 1024Mi
+              ephemeral-storage: 20Mi
           volumeMounts:
             - mountPath: /dev/shm
               name: dshm

--- a/config/manager/default-config/deployment.yaml
+++ b/config/manager/default-config/deployment.yaml
@@ -12,7 +12,7 @@ spec:
       labels:
         janus-idp.io/app:  # placeholder for 'backstage-<cr-name>'
     spec:
-      #      serviceAccountName: default
+      automountServiceAccountToken: false
       volumes:
         - ephemeral:
             volumeClaimTemplate:
@@ -47,7 +47,11 @@ spec:
               readOnly: true
               subPath: .npmrc
           workingDir: /opt/app-root/src
-
+          resources:
+            limits:
+              cpu: 400m
+              memory: 1Gi
+              ephemeral-storage: 3Gi
       containers:
         - name: backstage-backend
           image: <RELATED_IMAGE_backstage> # will be replaced with the actual image quay.io/janus-idp/backstage-showcase:next
@@ -89,3 +93,8 @@ spec:
           volumeMounts:
             - mountPath: /opt/app-root/src/dynamic-plugins-root
               name: dynamic-plugins-root
+          resources:
+            limits:
+              cpu: 400m
+              memory: 1Gi
+              ephemeral-storage: 3Gi

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -36,6 +36,7 @@ spec:
       labels:
         control-plane: controller-manager
     spec:
+      automountServiceAccountToken: true
       # TODO(user): Uncomment the following code to configure the nodeAffinity expression
       # according to the platforms which are supported by your solution. 
       # It is considered best practice to support multiple architectures. You can
@@ -100,6 +101,7 @@ spec:
           limits:
             cpu: 500m
             memory: 128Mi
+            ephemeral-storage: 20Mi
           requests:
             cpu: 10m
             memory: 64Mi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 #@follow_tag(registry.redhat.io/rhel9/go-toolset:latest)
-FROM registry.access.redhat.com/ubi9/go-toolset:1.20.10-6 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.20.10-6 AS builder
 # hadolint ignore=DL3002
 USER 0
 ENV GOPATH=/go/


### PR DESCRIPTION
Initial fix for https://issues.redhat.com/browse/RHIDP-1153

## Description

1. Initial resource limits set based on metrics-server measurment (needs more infomation based on operator monitoring, when available)
2. Fixed some automountServiceAccountToken issues

NOTES:
I think we need to fix some sonarLint rules, in particular:

1. Requirement to have resource limits and automountServiceAccountToken fixed on yaml patches (such as manager_auth_proxy_patch.yaml and manger_config_patch.yaml) does not seem correct b/c it is fixed on the main manifest.
2. Setting automountServiceAccountToken=false does not work for controller's SA, it is intentionally set to true.
3. Seems like requiring tag for Docker's "FROM scratch" makes no sense. 

## Which issue(s) does this PR fix or relate to

https://issues.redhat.com/browse/RHIDP-1153

## PR acceptance criteria

No issues in this report
https://sonarcloud.io/project/issues?resolved=false&types=VULNERABILITY&id=janus-idp_operator


