### PR TITLE
Auto-push bundle manifests changes to PR branch if needed

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,7 @@ Please explain the changes you made here.
 
 - [ ] Tests
 - [ ] Documentation
+- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.csv.yaml`](../.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file accordingly
 
 ## How to test changes / Special notes to the reviewer
 <!--

--- a/.github/workflows/pr-bundle-diff-checks.yaml
+++ b/.github/workflows/pr-bundle-diff-checks.yaml
@@ -1,4 +1,4 @@
-# Copyright 2023 The Janus IDP Authors
+# Copyright 2024 The Janus IDP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/pr-bundle-diff-checks.yaml
+++ b/.github/workflows/pr-bundle-diff-checks.yaml
@@ -1,0 +1,97 @@
+# Copyright 2023 The Janus IDP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: PR Bundle Manifests Validator
+
+on:
+  # pull_request_target needed to be able to commit and push bundle diffs to external fork PRs.
+  # But we included a manual authorization safeguard to prevent PWN requests. See the 'authorize' job below.
+  pull_request_target:
+    branches: 
+    - main
+    - rhdh-1.[0-9]+
+    - 1.[0-9]+.x
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+jobs:
+  authorize:
+    # The 'external' environment is configured with the maintainers team as required reviewers.
+    # All the subsequent jobs in this workflow 'need' this job, which will require manual approval for PRs coming from external forks.
+    # see list of approvers in OWNERS file
+    environment:
+      ${{ (github.event.pull_request.head.repo.full_name == github.repository ||
+      contains(fromJSON('["gazarenkov","jianrongzhang89","kadel","nickboldt","rm3l"]'), github.actor)) && 'internal' || 'external' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: approved
+        run: echo "✓"
+
+  pr-bundle-diff-checks:
+    name: PR Bundle Diff
+    runs-on: ubuntu-latest
+    needs: authorize
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Check for outdated bundle
+        id: bundle-diff-checker
+        run: |
+          make bundle
+          git status --porcelain
+          # Since operator-sdk 1.26.0, `make bundle` changes the `createdAt` field from the bundle every time we run it.
+          # The `git diff` below checks if only the createdAt field has changed. If is the only change, it is ignored.
+          # Inspired from https://github.com/operator-framework/operator-sdk/issues/6285#issuecomment-1415350333
+          echo "MANIFESTS_CHANGED=$(if git diff --quiet -I'^    createdAt: ' bundle; then echo "false"; else echo "true"; fi)" >> $GITHUB_OUTPUT
+
+      - name: Commit any manifest changes
+        if: ${{ steps.bundle-diff-checker.outputs.MANIFESTS_CHANGED == 'true' }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git fetch --prune
+          git pull --rebase --autostash
+          git add -A .
+          git commit \
+            -m "Regenerate bundle manifests" \
+            -m "Co-authored-by: $GITHUB_ACTOR <$GITHUB_ACTOR@users.noreply.github.com>"
+          git push
+
+      - name: Comment on PR if bundle manifests were updated
+        uses: actions/github-script@v7
+        if: ${{ !cancelled() && steps.bundle-diff-checker.outputs.MANIFESTS_CHANGED == 'true' }}
+        continue-on-error: true
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '⚠️ <b>Files changed in bundle generation<b>!<br/><br/>Those changes to the operator bundle manifests should have been pushed automatically to your PR branch.<br/>You might also need to manually update the [`.rhdh/bundle/manifests/rhdh-operator.csv.yaml`](.rhdh/bundle/manifests/rhdh-operator.csv.yaml) CSV file accordingly.'
+            })

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -81,10 +81,10 @@ jobs:
           retention-days: 5
 
       # gosec needs a "build" stage so connect it to the lint step which we always do
-      - name: build
+      - name: Lint
         run: make lint
 
-      - name: test
+      - name: Test
         # run this stage only if there are changes that match the includes and not the excludes
         if: ${{ env.CHANGES != '' }}
         run: make test

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -109,7 +109,7 @@ jobs:
             })
 
       # gosec needs a "build" stage so connect it to the lint step which we always do
-      - name: Lint
+      - name: build
         run: make lint
 
       - name: Test

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -56,29 +56,57 @@ jobs:
 
       - name: Check for outdated bundle
         id: bundle-diff-checker
+        # Lot of debate (https://github.com/janus-idp/operator/pull/195) whether this should be a warning or an error.
+        # For now, this is will be warning + a comment on the PR if manifests are outdated. This way, PR authors/maintainers can be aware of that fact.
+        continue-on-error: true
         run: |
           make bundle
           git status --porcelain
           # Since operator-sdk 1.26.0, `make bundle` changes the `createdAt` field from the bundle every time we run it.
           # The `git diff` below checks if only the createdAt field has changed. If is the only change, it is ignored.
           # Inspired from https://github.com/operator-framework/operator-sdk/issues/6285#issuecomment-1415350333
-          git diff --quiet -I'^    createdAt: ' bundle || ( echo "===================" && \
-            echo "Files changed in bundle generation." && \
-            echo "Please make sure to regenerate the bundle with 'make bundle' and push the changes." && \
-            echo "Make sure you unset any related env vars like VERSION or IMAGE_TAG_BASE or IMG before running this command, as they may affect the resulting manifests." && \
-            echo "For your convenience, the diff will be attached as a job artifact, so you can easily download and Git-apply it right away." && \
-            echo "You might also need to manually update the CSV in '.rhdh/bundle/manifests/rhdh-operator.csv.yaml' file accordingly." && \
-            echo "===================" && \
+          git diff --quiet -I'^    createdAt: ' bundle || ( echo "::group::WARNINGS" && \
             git --no-pager diff | tee bundle.pr-${{ github.event.number }}.patch && \
+            echo "::warning:: Files changed in bundle generation. Please regenerate the bundle with 'make bundle' and push the changes. For your convenience, the diff is attached as a job artifact, so you can easily download and Git-apply it right away instead. You might also need to manually update the CSV in '.rhdh/bundle/manifests/rhdh-operator.csv.yaml' file accordingly." && \
+            echo "::endgroup::" && \
             exit 1 )
 
       - name: Save bundle diff as patch
+        id: bundle-diff-patch-artifact-upload
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() && steps.bundle-diff-checker.outcome == 'failure' }}
         with:
           name: bundle-diff-patch
           path: bundle.pr-${{ github.event.number }}.patch
           retention-days: 5
+
+      - name: Comment on PR if bundle manifests are outdated
+        uses: actions/github-script@v7
+        if: ${{ !cancelled() && steps.bundle-diff-checker.outcome == 'failure' }}
+        # TODO(rm3l): this won't work for fork PRs due to permission restrictions. Remove this once this is fixed for fork PRs.
+        continue-on-error: true
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '⚠️ <b>Files changed in bundle generation<b>!<br/><br/>Please make sure to regenerate the bundle with `make bundle` and push the changes. Make sure you unset any related env vars like `VERSION` or `IMAGE_TAG_BASE` or `IMG` before running this command, as they may affect the resulting manifests.<br/>For your convenience, the diff is attached as a job artifact [here](${{ steps.bundle-diff-patch-artifact-upload.outputs.artifact-url }}), so you can easily download and Git-apply it right away instead of running `make bundle`.<br/>You might also need to manually update the CSV in [`.rhdh/bundle/manifests/rhdh-operator.csv.yaml`](.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file accordingly.'
+            })
+
+      - name: Comment on PR if bundle manifests are up-to-date
+        uses: actions/github-script@v7
+        if: ${{ !cancelled() && steps.bundle-diff-checker.outcome == 'success' }}
+        # TODO(rm3l): this won't work for fork PRs due to permission restrictions. Remove this once this is fixed for fork PRs.
+        continue-on-error: true
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '🎉 <b>Bundle manifests are up-to-date!<br/><br/>Please also review the bundle manifests to make sure manual updates to the CSV in [`.rhdh/bundle/manifests/rhdh-operator.csv.yaml`](.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file are not required.'
+            })
 
       # gosec needs a "build" stage so connect it to the lint step which we always do
       - name: Lint

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -54,6 +54,23 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
+      - name: Check for outdated bundle
+        run: |
+          make bundle
+          git status --porcelain
+          # Since operator-sdk 1.26.0, `make bundle` changes the `createdAt` field from the bundle every time we run it.
+          # The `git diff` below checks if only the createdAt field has changed. If is the only change, it is ignored.
+          # Inspired from https://github.com/operator-framework/operator-sdk/issues/6285#issuecomment-1415350333
+          git diff --quiet -I'^    createdAt: ' bundle || ( echo "===================" && \
+            echo "Files changed in bundle generation." && \
+            echo "Please make sure to regenerate the bundle with 'make bundle' and push the changes." && \
+            echo "Make sure you unset any related env vars like VERSION or IMAGE_TAG_BASE or IMG before running this command, as they may affect the resulting manifests." && \
+            echo "For your convenience, the diff will be attached as a job artifact, so you can easily download and Git-apply it right away." && \
+            echo "You might also need to manually update the CSV in '.rhdh/bundle/manifests/rhdh-operator.csv.yaml' file accordingly." && \
+            echo "===================" && \
+            git --no-pager diff && \
+            exit 1)
+
       # gosec needs a "build" stage so connect it to the lint step which we always do
       - name: build
         run: make lint

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -56,57 +56,29 @@ jobs:
 
       - name: Check for outdated bundle
         id: bundle-diff-checker
-        # Lot of debate (https://github.com/janus-idp/operator/pull/195) whether this should be a warning or an error.
-        # For now, this is will be warning + a comment on the PR if manifests are outdated. This way, PR authors/maintainers can be aware of that fact.
-        continue-on-error: true
         run: |
           make bundle
           git status --porcelain
           # Since operator-sdk 1.26.0, `make bundle` changes the `createdAt` field from the bundle every time we run it.
           # The `git diff` below checks if only the createdAt field has changed. If is the only change, it is ignored.
           # Inspired from https://github.com/operator-framework/operator-sdk/issues/6285#issuecomment-1415350333
-          git diff --quiet -I'^    createdAt: ' bundle || ( echo "::group::WARNINGS" && \
+          git diff --quiet -I'^    createdAt: ' bundle || ( echo "===================" && \
+            echo "Files changed in bundle generation." && \
+            echo "Please make sure to regenerate the bundle with 'make bundle' and push the changes." && \
+            echo "Make sure you unset any related env vars like VERSION or IMAGE_TAG_BASE or IMG before running this command, as they may affect the resulting manifests." && \
+            echo "For your convenience, the diff will be attached as a job artifact, so you can easily download and Git-apply it right away." && \
+            echo "You might also need to manually update the CSV in '.rhdh/bundle/manifests/rhdh-operator.csv.yaml' file accordingly." && \
+            echo "===================" && \
             git --no-pager diff | tee bundle.pr-${{ github.event.number }}.patch && \
-            echo "::warning:: Files changed in bundle generation. Please regenerate the bundle with 'make bundle' and push the changes. For your convenience, the diff is attached as a job artifact, so you can easily download and Git-apply it right away instead. You might also need to manually update the CSV in '.rhdh/bundle/manifests/rhdh-operator.csv.yaml' file accordingly." && \
-            echo "::endgroup::" && \
             exit 1 )
 
       - name: Save bundle diff as patch
-        id: bundle-diff-patch-artifact-upload
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() && steps.bundle-diff-checker.outcome == 'failure' }}
         with:
           name: bundle-diff-patch
           path: bundle.pr-${{ github.event.number }}.patch
           retention-days: 5
-
-      - name: Comment on PR if bundle manifests are outdated
-        uses: actions/github-script@v7
-        if: ${{ !cancelled() && steps.bundle-diff-checker.outcome == 'failure' }}
-        # TODO(rm3l): this won't work for fork PRs due to permission restrictions. Remove this once this is fixed for fork PRs.
-        continue-on-error: true
-        with:
-          script: |
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '⚠️ <b>Files changed in bundle generation<b>!<br/><br/>Please make sure to regenerate the bundle with `make bundle` and push the changes. Make sure you unset any related env vars like `VERSION` or `IMAGE_TAG_BASE` or `IMG` before running this command, as they may affect the resulting manifests.<br/>For your convenience, the diff is attached as a job artifact [here](${{ steps.bundle-diff-patch-artifact-upload.outputs.artifact-url }}), so you can easily download and Git-apply it right away instead of running `make bundle`.<br/>You might also need to manually update the CSV in [`.rhdh/bundle/manifests/rhdh-operator.csv.yaml`](.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file accordingly.'
-            })
-
-      - name: Comment on PR if bundle manifests are up-to-date
-        uses: actions/github-script@v7
-        if: ${{ !cancelled() && steps.bundle-diff-checker.outcome == 'success' }}
-        # TODO(rm3l): this won't work for fork PRs due to permission restrictions. Remove this once this is fixed for fork PRs.
-        continue-on-error: true
-        with:
-          script: |
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '🎉 <b>Bundle manifests are up-to-date!<br/><br/>Please also review the bundle manifests to make sure manual updates to the CSV in [`.rhdh/bundle/manifests/rhdh-operator.csv.yaml`](.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file are not required.'
-            })
 
       # gosec needs a "build" stage so connect it to the lint step which we always do
       - name: build

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -55,6 +55,7 @@ jobs:
           go-version-file: 'go.mod'
 
       - name: Check for outdated bundle
+        id: bundle-diff-checker
         run: |
           make bundle
           git status --porcelain
@@ -68,8 +69,16 @@ jobs:
             echo "For your convenience, the diff will be attached as a job artifact, so you can easily download and Git-apply it right away." && \
             echo "You might also need to manually update the CSV in '.rhdh/bundle/manifests/rhdh-operator.csv.yaml' file accordingly." && \
             echo "===================" && \
-            git --no-pager diff && \
-            exit 1)
+            git --no-pager diff | tee bundle.pr-${{ github.event.number }}.patch && \
+            exit 1 )
+
+      - name: Save bundle diff as patch
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() && steps.bundle-diff-checker.outcome == 'failure' }}
+        with:
+          name: bundle-diff-patch
+          path: bundle.pr-${{ github.event.number }}.patch
+          retention-days: 5
 
       # gosec needs a "build" stage so connect it to the lint step which we always do
       - name: build

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,10 +21,6 @@ on:
     - rhdh-1.[0-9]+
     - 1.[0-9]+.x
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.number }}
-  cancel-in-progress: true
-
 jobs:
   pr-validate:
     name: PR Validate
@@ -34,10 +30,6 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           fetch-depth: 0
-          # Check out PR HEAD ref instead of the default merge commit (detached).
-          # Otherwise, it will be impossible for the bundle-diff-checker step to auto-push any outstanding changes.
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{github.event.pull_request.head.repo.full_name}}
 
       # check changes in this commit for regex include and exclude matches; pipe to an env var
       - name: Check for changes to build
@@ -62,34 +54,11 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Check for outdated bundle
-        id: bundle-diff-checker
-        run: |
-          make bundle
-          git status --porcelain
-          # Since operator-sdk 1.26.0, `make bundle` changes the `createdAt` field from the bundle every time we run it.
-          # The `git diff` below checks if only the createdAt field has changed. If is the only change, it is ignored.
-          # Inspired from https://github.com/operator-framework/operator-sdk/issues/6285#issuecomment-1415350333
-          echo "MANIFESTS_CHANGED=$(if git diff --quiet -I'^    createdAt: ' bundle; then echo "false"; else echo "true"; fi)" >> $GITHUB_OUTPUT
-
-      - name: Commit any manifest changes
-        if: ${{ steps.bundle-diff-checker.outputs.MANIFESTS_CHANGED == 'true' }}
-        run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git fetch --prune
-          git pull --rebase --autostash
-          git add -A .
-          git commit \
-            -m "Regenerate bundle manifests" \
-            -m "Co-authored-by: $GITHUB_ACTOR <$GITHUB_ACTOR@users.noreply.github.com>"
-          git push
-
       # gosec needs a "build" stage so connect it to the lint step which we always do
       - name: build
         run: make lint
 
-      - name: Test
+      - name: test
         # run this stage only if there are changes that match the includes and not the excludes
         if: ${{ env.CHANGES != '' }}
         run: make test

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,6 +21,10 @@ on:
     - rhdh-1.[0-9]+
     - 1.[0-9]+.x
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
+
 jobs:
   pr-validate:
     name: PR Validate
@@ -30,6 +34,10 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           fetch-depth: 0
+          # Check out PR HEAD ref instead of the default merge commit (detached).
+          # Otherwise, it will be impossible for the bundle-diff-checker step to auto-push any outstanding changes.
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
 
       # check changes in this commit for regex include and exclude matches; pipe to an env var
       - name: Check for changes to build
@@ -62,23 +70,20 @@ jobs:
           # Since operator-sdk 1.26.0, `make bundle` changes the `createdAt` field from the bundle every time we run it.
           # The `git diff` below checks if only the createdAt field has changed. If is the only change, it is ignored.
           # Inspired from https://github.com/operator-framework/operator-sdk/issues/6285#issuecomment-1415350333
-          git diff --quiet -I'^    createdAt: ' bundle || ( echo "===================" && \
-            echo "Files changed in bundle generation." && \
-            echo "Please make sure to regenerate the bundle with 'make bundle' and push the changes." && \
-            echo "Make sure you unset any related env vars like VERSION or IMAGE_TAG_BASE or IMG before running this command, as they may affect the resulting manifests." && \
-            echo "For your convenience, the diff will be attached as a job artifact, so you can easily download and Git-apply it right away." && \
-            echo "You might also need to manually update the CSV in '.rhdh/bundle/manifests/rhdh-operator.csv.yaml' file accordingly." && \
-            echo "===================" && \
-            git --no-pager diff | tee bundle.pr-${{ github.event.number }}.patch && \
-            exit 1 )
+          echo "MANIFESTS_CHANGED=$(if git diff --quiet -I'^    createdAt: ' bundle; then echo "false"; else echo "true"; fi)" >> $GITHUB_OUTPUT
 
-      - name: Save bundle diff as patch
-        uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() && steps.bundle-diff-checker.outcome == 'failure' }}
-        with:
-          name: bundle-diff-patch
-          path: bundle.pr-${{ github.event.number }}.patch
-          retention-days: 5
+      - name: Commit any manifest changes
+        if: ${{ steps.bundle-diff-checker.outputs.MANIFESTS_CHANGED == 'true' }}
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git fetch --prune
+          git pull --rebase --autostash
+          git add -A .
+          git commit \
+            -m "Regenerate bundle manifests" \
+            -m "Co-authored-by: $GITHUB_ACTOR <$GITHUB_ACTOR@users.noreply.github.com>"
+          git push
 
       # gosec needs a "build" stage so connect it to the lint step which we always do
       - name: build

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -104,7 +104,9 @@ make deploy-openshift [IMAGE_TAG_BASE=<your-registry>/backstage-operator]
 ```
 
 ### Modifying the API definitions
-If you are editing the API definitions, regenerate the manifests and bundle using:
+If you are editing the API definitions, make sure you:
+- run `make install` before deploying the operator with `make deploy`
+- regenerate the manifests and bundle if you plan to deploy the operator with OLM using:
 ```sh
 make manifests bundle
 ```

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -104,11 +104,11 @@ make deploy-openshift [IMAGE_TAG_BASE=<your-registry>/backstage-operator]
 ```
 
 ### Modifying the API definitions
-If you are editing the API definitions, generate the manifests such as CRs or CRDs using:
+If you are editing the API definitions, regenerate the bundle using:
 ```sh
-make manifests
+make bundle
 ```
-**NOTE:** Run `make --help` for more information on all potential `make` targets
+**NOTE:** Run `make help` for more information on all potential `make` targets
 
 More information can be found via the [Kubebuilder Documentation](https://book.kubebuilder.io/introduction.html)
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -104,9 +104,9 @@ make deploy-openshift [IMAGE_TAG_BASE=<your-registry>/backstage-operator]
 ```
 
 ### Modifying the API definitions
-If you are editing the API definitions, regenerate the bundle using:
+If you are editing the API definitions, regenerate the manifests and bundle using:
 ```sh
-make bundle
+make manifests bundle
 ```
 **NOTE:** Run `make help` for more information on all potential `make` targets
 


### PR DESCRIPTION
## Description
This is to ensure bundle manifests are kept updated when submitting a PR. 

## Which issue(s) does this PR fix or relate to
This is a follow-up PR to https://github.com/janus-idp/operator/pull/187#issuecomment-1938816003

## PR acceptance criteria

- [ ] Tests
- [x] Documentation

## How to test changes / Special notes to the reviewer
- ~https://github.com/janus-idp/operator/actions/runs/7878373268?pr=195 is an example of run with outdated bundle manifests~
- ~After applying the resulting patch (attached as a job artifact) or after regenerating the bundle with `make bundle`, the job passes successfully, e.g.: https://github.com/janus-idp/operator/actions/runs/7878650096/job/21497344358?pr=195~

Because the workflow is triggered on `pull_request_target` events, this PR will need to be merged into the base branch to see it in action.
