### PR TITLE
Port latest changes (`automountServiceAccountToken` and ephemeral storage limit) to downstream CSV for RHDH

### DIFF
--- a/.rhdh/bundle/manifests/rhdh-operator.csv.yaml
+++ b/.rhdh/bundle/manifests/rhdh-operator.csv.yaml
@@ -190,6 +190,7 @@ spec:
                         operator: In
                         values:
                         - linux
+              automountServiceAccountToken: true
               containers:
               - args:
                 - --secure-listen-address=0.0.0.0:8443
@@ -248,6 +249,7 @@ spec:
                 resources:
                   limits:
                     cpu: 500m
+                    ephemeral-storage: 20Mi
                     memory: 128Mi
                   requests:
                     cpu: 10m


### PR DESCRIPTION
## Description
This is an addendum commit to https://github.com/janus-idp/operator/pull/185

## Which issue(s) does this PR fix or relate to
&mdash;

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
&mdash;