### PR TITLE
Set `VERSION` to `0.1.0-dev` in Makefile for `main` branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.0.1
+VERSION ?= 0.1.0-dev
 
 # Using docker or podman to build and push images
 CONTAINER_ENGINE ?= docker

--- a/bundle/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/backstage-operator.clusterserviceversion.yaml
@@ -21,11 +21,11 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2024-02-13T07:11:47Z"
+    createdAt: "2024-02-16T16:44:06Z"
     operatorframework.io/suggested-namespace: backstage-system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: backstage-operator.v0.0.1
+  name: backstage-operator.v0.1.0-dev
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -221,7 +221,7 @@ spec:
                   value: quay.io/fedora/postgresql-15:latest
                 - name: RELATED_IMAGE_backstage
                   value: quay.io/janus-idp/backstage-showcase:latest
-                image: quay.io/janus-idp/operator:0.0.1
+                image: quay.io/janus-idp/operator:0.1.0-dev
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -326,4 +326,4 @@ spec:
     name: postgresql
   - image: quay.io/janus-idp/backstage-showcase:latest
     name: backstage
-  version: 0.0.1
+  version: 0.1.0-dev

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,7 +5,7 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/janus-idp/operator
-  newTag: 0.0.1
+  newTag: 0.1.0-dev
 
 generatorOptions:
   disableNameSuffixHash: true


### PR DESCRIPTION
## Description
As discussed in [1], it would make sense to use different `VERSION` on `main` and release branches.

[1] https://github.com/janus-idp/operator/pull/200#discussion_r1489312876

## Which issue(s) does this PR fix or relate to

&mdash;

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
