### PR TITLE
Fix tags for images built for main and release branches

### DIFF
--- a/.github/workflows/next-container-build.yaml
+++ b/.github/workflows/next-container-build.yaml
@@ -98,7 +98,8 @@ jobs:
           if [[ $(git rev-parse --abbrev-ref HEAD) != "main" ]]; then
             latestNext="latest" 
           fi
-          export VERSION=${{ env.BASE_VERSION }}-${latestNext}-${{ env.SHORT_SHA }}
+
+          export VERSION=${{ env.BASE_VERSION }}
 
           set -ex
 
@@ -108,7 +109,6 @@ jobs:
           # now copy images from local cache to quay, using 0.0.1-next-f00cafe, 0.0.1-next, and next tags
           for image in operator operator-bundle operator-catalog; do
             podman push quay.io/janus-idp/${image}:${VERSION} -q
-            skopeo --insecure-policy copy --all docker://quay.io/janus-idp/${image}:${VERSION} docker://quay.io/janus-idp/${image}:${VERSION}
-            skopeo --insecure-policy copy --all docker://quay.io/janus-idp/${image}:${VERSION} docker://quay.io/janus-idp/${image}:${VERSION%-*}
+            skopeo --insecure-policy copy --all docker://quay.io/janus-idp/${image}:${VERSION} docker://quay.io/janus-idp/${image}:${VERSION}-${{ env.SHORT_SHA }}
             skopeo --insecure-policy copy --all docker://quay.io/janus-idp/${image}:${VERSION} docker://quay.io/janus-idp/${image}:${latestNext}
           done


### PR DESCRIPTION
## Description
As discussed in [1], this would allow to run `make deploy` out of the box, as the image corresponding to the VERSION in Makefile would be present.

[1] https://github.com/janus-idp/operator/pull/200#discussion_r1489312876

## Which issue(s) does this PR fix or relate to

&mdash;

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
This should fix the issue behind https://github.com/janus-idp/operator/pull/200