### PR TITLE
update dependencies

### DIFF
--- a/.rhdh/docker/Dockerfile
+++ b/.rhdh/docker/Dockerfile
@@ -55,7 +55,7 @@ RUN export ARCH="$(uname -m)" && if [[ ${ARCH} == "x86_64" ]]; then export ARCH=
 # Install openssl for FIPS support
 #@follow_tag(registry.redhat.io/ubi9/ubi-minimal:latest)
 FROM registry.access.redhat.com/ubi9-minimal:9.3-1475 AS runtime
-RUN microdnf install -y openssl; microdnf clean -y all
+RUN microdnf update --setopt=install_weak_deps=0 -y && microdnf install -y openssl; microdnf clean -y all
 
 # Upstream sources
 # Downstream comment

--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,8 @@ GOLANGCI_LINT_VERSION ?= v1.55.2
 GOIMPORTS_VERSION ?= v0.15.0
 ADDLICENSE_VERSION ?= v1.1.1
 # opm and operator-sdk version
-OP_VERSION ?= v1.36.0
+OPM_VERSION ?= v1.36.0
+OPERATOR_SDK_VERSION ?= v1.33.0
 GOSEC_VERSION ?= v2.18.2
 
 ## Gosec options - default format is sarif so we can integrate with Github code scanning
@@ -271,8 +272,8 @@ ifeq (,$(wildcard $(OPSDK)))
 	set -e ;\
 	mkdir -p $(dir $(OPSDK)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	echo "Dowloading https://github.com/operator-framework/operator-sdk/releases/download/$(OP_VERSION)/operator-sdk_$${OS}_$${ARCH} to ./bin/operator-sdk" ;\
-	curl -sSLo $(OPSDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OP_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
+	echo "Dowloading https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} to ./bin/operator-sdk" ;\
+	curl -sSLo $(OPSDK) https://github.com/operator-framework/operator-sdk/releases/download/$(OPERATOR_SDK_VERSION)/operator-sdk_$${OS}_$${ARCH} ;\
 	chmod +x $(OPSDK) ;\
 	}
 endif
@@ -285,8 +286,8 @@ ifeq (,$(wildcard $(OPM)))
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	echo "Dowloading https://github.com/operator-framework/operator-registry/releases/download/$(OP_VERSION)/$${OS}-$${ARCH}-opm to ./bin/opm" ;\
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/$(OP_VERSION)/$${OS}-$${ARCH}-opm ;\
+	echo "Dowloading https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/$${OS}-$${ARCH}-opm to ./bin/opm" ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}
 endif

--- a/Makefile
+++ b/Makefile
@@ -220,7 +220,7 @@ GOLANGCI_LINT_VERSION ?= v1.55.2
 GOIMPORTS_VERSION ?= v0.15.0
 ADDLICENSE_VERSION ?= v1.1.1
 # opm and operator-sdk version
-OP_VERSION ?= v1.33.0
+OP_VERSION ?= v1.36.0
 GOSEC_VERSION ?= v2.18.2
 
 ## Gosec options - default format is sarif so we can integrate with Github code scanning

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,7 +55,7 @@ RUN export ARCH="$(uname -m)" && if [[ ${ARCH} == "x86_64" ]]; then export ARCH=
 # Install openssl for FIPS support
 #@follow_tag(registry.redhat.io/ubi9/ubi-minimal:latest)
 FROM registry.access.redhat.com/ubi9-minimal:9.3-1475 AS runtime
-RUN microdnf install -y openssl; microdnf clean -y all
+RUN microdnf update --setopt=install_weak_deps=0 -y && microdnf install -y openssl; microdnf clean -y all
 
 # Upstream sources
 # Downstream comment


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Please explain the changes you made here.
-->

- Added the `microdnf update --setopt=install_weak_deps=0 -y` command to ensure our base image is staying up to date with the latest patches without having to update the base image version itself
- Updated opm/operator sdk to [v1.36.0](https://github.com/operator-framework/operator-registry/releases/tag/v1.36.0).  This will not fix the container image vulnerability but it patches other areas.

## Which issue(s) does this PR fix or relate to

- Fixes #_issue_number_
- https://issues.redhat.com/browse/RHIDP-1372

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->

Verified locally build image scan findings are [clean](https://quay.io/repository/ktsao/operator/manifest/sha256:aa9fd25e1e2b7c308f7e9de895e07b6a86363ae41264d791976f1fa542d2bd86?tab=vulnerabilities)
