### PR TITLE
fix: increase default size of the dynamic-plugins-root volume from 1Gi to 2Gi

### DIFF
--- a/bundle/manifests/backstage-default-config_v1_configmap.yaml
+++ b/bundle/manifests/backstage-default-config_v1_configmap.yaml
@@ -180,7 +180,7 @@ data:
                       - ReadWriteOnce
                     resources:
                       requests:
-                        storage: 1Gi
+                        storage: 2Gi
               name: dynamic-plugins-root
             - name: dynamic-plugins-npmrc
               secret:

--- a/config/manager/default-config/deployment.yaml
+++ b/config/manager/default-config/deployment.yaml
@@ -21,7 +21,7 @@ spec:
                   - ReadWriteOnce
                 resources:
                   requests:
-                    storage: 1Gi
+                    storage: 2Gi
           name: dynamic-plugins-root
         - name: dynamic-plugins-npmrc
           secret:


### PR DESCRIPTION
## Description
This applies the same fix done in the Helm Chart [1].

As depicted in [2], the init container might fail with insufficient
space error:
```
======= Installing dynamic plugin ./dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic
==> Grabbing package archive through `npm pack`
 Traceback (most recent call last):
  File "/opt/app-root/src/install-dynamic-plugins.py", line 304, in <module> main()
   File "/opt/app-root/src/install-dynamic-plugins.py", line 230, in main
    raise InstallException(f'Error while installing plugin \{ package } with \'npm pack\' : ' + completed.stderr.decode('utf-8')) __main__.InstallException: Error while installing plugin /opt/app-root/src/dynamic-plugins/dist/backstage-plugin-scaffolder-backend-module-github-dynamic with 'npm pack' : npm notice npm notice New major version of npm available! 9.8.1 -> 10.4.0 npm notice Changelog: <https://github.com/npm/cli/releases/tag/v10.4.0> npm notice Run `npm install -g npm@10.4.0` to update! npm notice npm ERR! code ENOSPC npm ERR! syscall open npm ERR! path /dynamic-plugins-root/backstage-plugin-scaffolder-backend-module-github-dynamic-0.2.0-next.3.tgz npm ERR! errno -28 npm ERR! nospc ENOSPC: no space left on device, open '/dynamic-plugins-root/backstage-plugin-scaffolder-backend-module-github-dynamic-0.2.0-next.3.tgz' npm ERR! nospc
 There appears to be insufficient space on your system to finish. npm ERR! nospc Clear up some disk space and try again.
```

[1] https://github.com/redhat-developer/rhdh-chart/pull/5
[2] https://issues.redhat.com/browse/RHIDP-1332

## Which issue(s) does this PR fix or relate to

- Fixes https://issues.redhat.com/browse/RHIDP-1332

## PR acceptance criteria

- [x] Tests
- [ ] Documentation

## How to test changes / Special notes to the reviewer
See https://issues.redhat.com/browse/RHIDP-1332
