### PR TITLE
chore: RHIDP-1105 switch annotations.yaml back to use fast channels; clean up comments

### DIFF
--- a/.rhdh/bundle/metadata/annotations.yaml
+++ b/.rhdh/bundle/metadata/annotations.yaml
@@ -3,5 +3,5 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: rhdh
-  operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.bundle.channels.v1: stable,stable-${CI_X_VERSION}.${CI_Y_VERSION}
+  operators.operatorframework.io.bundle.channel.default.v1: fast
+  operators.operatorframework.io.bundle.channels.v1: fast,fast-${CI_X_VERSION}.${CI_Y_VERSION}

--- a/.rhdh/scripts/prepare-restricted-environment.sh
+++ b/.rhdh/scripts/prepare-restricted-environment.sh
@@ -34,7 +34,7 @@ done
 declare prod_operator_index="${prod_operator_index:?Must set --prod_operator_index: for OCP 4.12, use registry.redhat.io/redhat/redhat-operator-index:v4.12 or quay.io/rhdh/iib:latest-v4.14-x86_64}"
 declare prod_operator_package_name="rhdh"
 declare prod_operator_bundle_name="rhdh-operator"
-declare prod_operator_version="${prod_operator_version:?Must set --prod_operator_version: for stable channel, use v1.1.0; for stable-1.1 channel, use v1.1.1}" # eg., v1.1.0 or v1.1.1
+declare prod_operator_version="${prod_operator_version:?Must set --prod_operator_version: for fast or fast-1.y channels, use v1.1.0, v1.1.1, etc.}"
 
 # Destination registry
 declare my_operator_index_image_name_and_tag=${prod_operator_package_name}-index:${prod_operator_version}


### PR DESCRIPTION
Signed-off-by: RHDH Build...

  ### What does this PR do?

chore: [RHIDP-1105](https://issues.redhat.com//browse/RHIDP-1105) switch annotations.yaml back to use fast channels; clean up comments

Signed-off-by: RHDH Build (rhdh-bot) <rhdh-bot@redhat.com>

### Screenshot/screencast of this PR
N/A

### What issues does this PR fix or reference?
https://issues.redhat.com/browse/RHIDP-1105

### How to test this PR?
merge, then merge https://gitlab.cee.redhat.com/rhidp/rhdh/-/merge_requests/8/diffs
build new IIBs in quay
install with either https://github.com/janus-idp/operator/blob/main/.rhdh/scripts/install-rhdh-catalog-source.sh or `build/scripts/installCatalogSourceFromIIB.sh` (from https://gitlab.cee.redhat.com/rhidp/rhdh/)


### PR Checklist

[As the author of this Pull Request I made sure that:](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#pull-request-template-and-its-checklist)

- [x] [The Eclipse Contributor Agreement is valid](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-eclipse-contributor-agreement-is-valid)
- [x] [Code produced is complete](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-produced-is-complete)
- [x] [Code builds without errors](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#code-builds-without-errors)
- [ ] [Tests are covering the bugfix](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#tests-are-covering-the-bugfix)
- [x] [The repository devfile is up to date and works, if one exists](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#the-repository-devfile-is-up-to-date-and-works)
- [x] [Sections What issues does this PR fix or reference and How to test this PR completed](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#sections-what-issues-does-this-pr-fix-or-reference-and-how-to-test-this-pr-completed)
- [x] [Relevant user documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [Relevant contributing documentation updated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#relevant-contributing-documentation-updated)
- [x] [CI/CD changes implemented, documented and communicated](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md#cicd-changes-implemented-documented-and-communicated)

### Reviewers

Reviewers, please comment how you tested the PR when approving it.