### PR TITLE
pin setup-envtest to fix test breakage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,7 +247,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@c7e1dc9b5302d649d5531e19168dd7ea0013736d
 
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Please explain the changes you made here.
-->
Current PR tests are failing due to this error:
`
go: sigs.k8s.io/controller-runtime/tools/setup-envtest@latest (in sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20240326031119-8afbb50e0eb2): go.mod:3: invalid go version '1.22.0': must match format 1.23`

as a result of this change https://github.com/kubernetes-sigs/controller-runtime/issues/2720#issuecomment-2016461180
We need to pin to an older commit in order to work around this.

## Which issue(s) does this PR fix or relate to

- Fixes #_issue_number_

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.csv.yaml`](../.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file accordingly

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
