### PR TITLE
update renovate to include vulnerability alerts

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,10 +4,9 @@
     ":gitSignOff",
     ":rebaseStalePrs",
     "docker:enableMajor",
-    "group:allNonMajor",
-    "group:linters",
-    "group:test"
+    "group:allNonMajor"
   ],
+  "labels": ["kind/dependency upgrade"],
   "constraints": {
     "go": "1.20"
   },
@@ -18,5 +17,10 @@
       ],
       "pinDigests": false
     }
-  ]  
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "addLabels": ["kind/security"]
+  },
+  "osvVulnerabilityAlerts": true
 }


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Please explain the changes you made here.
-->

* Added integration with Github [vulnerability alerts](https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts).  Need to make corresponding repo settings changes to disable Dependabot and Group Security Updates
* Added config for [osvVulnerabilityAlerts](https://docs.renovatebot.com/configuration-options/#osvvulnerabilityalerts).  This is experimental but may be worth trying since it'll raise PRs on vulns found against direct dependencies whereas most, if not all dependabot findings affect transitive dependencies.  
* Removed the `group:linters` and `group:test` presets since these are specific only to js and irrelevant to this repo


## Which issue(s) does this PR fix or relate to

- Fixes https://issues.redhat.com/browse/RHIDP-1737
## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.csv.yaml`](../.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file accordingly

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
