### PR TITLE
chore: Update list of GH users not requiring manual approval for `pull_request_target` Workflows

### DIFF
--- a/.github/workflows/pr-bundle-diff-checks.yaml
+++ b/.github/workflows/pr-bundle-diff-checks.yaml
@@ -34,7 +34,7 @@ jobs:
     # see list of approvers in OWNERS file
     environment:
       ${{ (github.event.pull_request.head.repo.full_name == github.repository ||
-      contains(fromJSON('["gazarenkov","jianrongzhang89","kadel","nickboldt","rm3l"]'), github.actor)) && 'internal' || 'external' }}
+      contains(fromJSON('["gazarenkov","jianrongzhang89","kadel","nickboldt","rm3l","kim-tsao","openshift-cherrypick-robot"]'), github.actor)) && 'internal' || 'external' }}
     runs-on: ubuntu-latest
     steps:
       - name: approved

--- a/.github/workflows/pr-container-build.yaml
+++ b/.github/workflows/pr-container-build.yaml
@@ -41,7 +41,7 @@ jobs:
     # see list of approvers in OWNERS file
     environment:
       ${{ (github.event.pull_request.head.repo.full_name == github.repository ||
-        contains(fromJSON('["gazarenkov","jianrongzhang89","kadel","nickboldt","rm3l"]'), github.actor)) && 'internal' || 'external' }}
+        contains(fromJSON('["gazarenkov","jianrongzhang89","kadel","nickboldt","rm3l","kim-tsao","openshift-cherrypick-robot"]'), github.actor)) && 'internal' || 'external' }}
     runs-on: ubuntu-latest
     steps:
       - name: approved


### PR DESCRIPTION
## Description

Otherwise, this requires manual approval to trigger those workflows

- Add @kim-tsao
- Add @openshift-cherrypick-robot

## Which issue(s) does this PR fix or relate to
&mdash;

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.csv.yaml`](../.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file accordingly

## How to test changes / Special notes to the reviewer
&mdash;