### PR TITLE
Fix E2E tests by changing the list of extra dynamic plugins added to `examples/rhdh-cr-with-app-configs.yaml`

### DIFF
--- a/examples/rhdh-cr-with-app-configs.yaml
+++ b/examples/rhdh-cr-with-app-configs.yaml
@@ -108,6 +108,7 @@ metadata:
 data:
   dynamic-plugins.yaml: |
     includes:
+      # https://github.com/janus-idp/backstage-showcase/blob/main/dynamic-plugins.default.yaml
       - dynamic-plugins.default.yaml
     plugins:
       - package: './dynamic-plugins/dist/backstage-plugin-catalog-backend-module-github-dynamic'
@@ -124,15 +125,34 @@ data:
                     # supports ISO duration, "human duration (used below)
                     timeout: { minutes: 3}
                     initialDelay: { seconds: 15}
-      - package: '@dfatwork-pkgs/scaffolder-backend-module-http-request-wrapped-dynamic@4.0.9-0'
-        integrity: 'sha512-+YYESzHdg1hsk2XN+zrtXPnsQnfbzmWIvcOM0oQLS4hf8F4iGTtOXKjWnZsR/14/khGsPrzy0oq1ytJ1/4ORkQ=='
-      - package: '@dfatwork-pkgs/explore-backend-wrapped-dynamic@0.0.9-next.11'
-        integrity: 'sha512-/qUxjSedxQ0dmYqMWsZ2+OLGeovaaigRRrX1aTOz0GJMwSjOAauUUD1bMs56VPX74qWL1rf3Xr4nViiKo8rlIA=='
+      - package: ./dynamic-plugins/dist/backstage-plugin-techdocs-backend-dynamic
         pluginConfig:
-          proxy:
-            endpoints:
-              /explore-backend-completed:
-                target: 'http://localhost:7017'
+          # Reference documentation http://backstage.io/docs/features/techdocs/configuration
+          # Note: After experimenting with basic setup, use CI/CD to generate docs
+          # and an external cloud storage when deploying TechDocs for production use-case.
+          # https://backstage.io/docs/features/techdocs/how-to-guides#how-to-migrate-from-techdocs-basic-to-recommended-deployment-approach
+          techdocs:
+            builder: local
+            generator:
+              runIn: local
+            publisher:
+              type: local
+      - package: ./dynamic-plugins/dist/backstage-plugin-catalog-backend-module-gitlab-dynamic
+        disabled: false
+        pluginConfig:
+          catalog:
+            providers:
+              gitlab: {}
+      # Packages below do not seem compatible with the latest 1.1.x of the Showcase image: they prevent the Backstage process from running successfully
+      #- package: '@dfatwork-pkgs/scaffolder-backend-module-http-request-wrapped-dynamic@4.0.9-0'
+      #  integrity: 'sha512-+YYESzHdg1hsk2XN+zrtXPnsQnfbzmWIvcOM0oQLS4hf8F4iGTtOXKjWnZsR/14/khGsPrzy0oq1ytJ1/4ORkQ=='
+      #- package: '@dfatwork-pkgs/explore-backend-wrapped-dynamic@0.0.9-next.11'
+      #  integrity: 'sha512-/qUxjSedxQ0dmYqMWsZ2+OLGeovaaigRRrX1aTOz0GJMwSjOAauUUD1bMs56VPX74qWL1rf3Xr4nViiKo8rlIA=='
+      #  pluginConfig:
+      #    proxy:
+      #      endpoints:
+      #        /explore-backend-completed:
+      #          target: 'http://localhost:7017'
                 
 ---
 apiVersion: v1

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -82,8 +82,8 @@ var _ = Describe("Backstage Operator E2E", func() {
 						ExpectedHttpStatusCode: 200,
 						BodyMatcher: SatisfyAll(
 							ContainSubstring("backstage-plugin-catalog-backend-module-github-dynamic"),
-							ContainSubstring("@dfatwork-pkgs/scaffolder-backend-module-http-request-wrapped-dynamic"),
-							ContainSubstring("@dfatwork-pkgs/explore-backend-wrapped-dynamic"),
+							ContainSubstring("backstage-plugin-techdocs-backend-dynamic"),
+							ContainSubstring("backstage-plugin-catalog-backend-module-gitlab-dynamic"),
 						),
 					},
 				},

--- a/tests/helper/helper_backstage.go
+++ b/tests/helper/helper_backstage.go
@@ -142,6 +142,7 @@ func VerifyBackstageRoute(g Gomega, ns string, crName string, tests []ApiEndpoin
 
 	performTest := func(tt ApiEndpointTest) {
 		url := fmt.Sprintf("https://%s/%s", host, strings.TrimPrefix(tt.Endpoint, "/"))
+		fmt.Fprintf(GinkgoWriter, "--> GET %q\n", url)
 		resp, rErr := httpClient.Get(url)
 		g.Expect(rErr).ShouldNot(HaveOccurred(), fmt.Sprintf("error while trying to GET %q", url))
 		defer resp.Body.Close()


### PR DESCRIPTION
## Description
The plugins from `@dfatwork-pkgs/*` do not seem to work with the latest version of the Showcase image, as they prevent the Backstage process from starting correctly, making the Backstage pod crash.

## Which issue(s) does this PR fix or relate to
&mdash;

## PR acceptance criteria

- [x] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.csv.yaml`](../.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file accordingly

## How to test changes / Special notes to the reviewer
- You need an OpenShift cluster, as we need to check the Routes
- Before this PR, `make test-e2e` would not pass because of `examples/rhdh-cr-with-app-configs.yaml`. Now running `make test-e2e` should pass.