### PR TITLE
Add `examples/bs-existing-secret.yaml` to the list of E2E tests

### DIFF
--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -88,6 +88,11 @@ var _ = Describe("Backstage Operator E2E", func() {
 					},
 				},
 			},
+			{
+				name:       "with custom DB auth secret",
+				crFilePath: filepath.Join("examples", "bs-existing-secret.yaml"),
+				crName:     "bs-existing-secret",
+			},
 		} {
 			tt := tt
 			When(fmt.Sprintf("applying %s (%s)", tt.name, tt.crFilePath), func() {


### PR DESCRIPTION
## Description
This includes `examples/bs-existing-secret.yaml` to the list of E2E tests, as I noticed in https://github.com/janus-idp/operator/pull/272#discussion_r1544585522 that it could be tested as well.

## Which issue(s) does this PR fix or relate to
&mdash;

## PR acceptance criteria

- [x] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.csv.yaml`](../.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file accordingly

## How to test changes / Special notes to the reviewer
`make test-e2e` should pass on both OpenShift and Kubernetes. Well, except the one testing `examples/rhdh-cr-with-app-configs.yaml` on OpenShift, which should be fixed by #286.