### PR TITLE
Fix the nightly Workflow by installing the right version of Go

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -46,6 +46,13 @@ jobs:
             echo EOF
           } >> "$GITHUB_ENV"
 
+      - name: Setup Go
+        # run this stage only if there are changes that match the includes and not the excludes
+        if: ${{ env.CHANGES != '' }}
+        uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
+        with:
+          go-version-file: 'go.mod'
+
       - name: Determine built operator image
         # run this stage only if there are changes that match the includes and not the excludes
         if: ${{ env.CHANGES != '' }}


### PR DESCRIPTION
## Description
Otherwise Go 1.21 was available by default in the current runner, and caused the error we saw, like here: https://github.com/janus-idp/operator/actions/runs/8544126445/job/23409466635.

```
go: downloading github.com/davecgh/go-spew v1.1.1
go: downloading github.com/go-openapi/jsonpointer v0.19.6
go: downloading github.com/mailru/easyjson v0.7.7
go: downloading github.com/emicklei/go-restful/v3 v3.11.0
go: downloading github.com/josharian/intern v1.0.0
go: updates to go.mod needed; to update it:
	go mod tidy
mkdir -p /home/runner/work/operator/operator/bin
test -s /home/runner/work/operator/operator/bin/ginkgo || GOBIN=/home/runner/work/operator/operator/bin go install github.com/onsi/ginkgo/v2/ginkgo@v2.17.1
go: downloading github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572
go: downloading golang.org/x/tools v0.17.0
go: downloading github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38
/home/runner/work/operator/operator/bin/ginkgo  --randomize-all --poll-progress-after=120s --poll-progress-interval=120s -timeout 14400s --no-color -nodes=1 tests/e2e
Failed to compile e2e:

go: updates to go.mod needed; to update it:
	go mod tidy

Ginkgo ran 1 suite in 32.74767ms

Test Suite Failed
make: *** [Makefile:409: test-e2e] Error 1
```

## Which issue(s) does this PR fix or relate to
&mdash;

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.csv.yaml`](../.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file accordingly

## How to test changes / Special notes to the reviewer
Nightly workflow should now pass.