### PR TITLE
Run E2E tests against the latest/next available operator images

### DIFF
--- a/.github/workflows/next-container-build.yaml
+++ b/.github/workflows/next-container-build.yaml
@@ -42,7 +42,27 @@ jobs:
         with:
           fetch-depth: 0
 
+      # check changes in this commit for regex include and exclude matches; pipe to an env var
+      - name: Check for changes to build
+        run: |
+          # don't fail if nothing returned by grep
+          set +e 
+          CHANGES="$(git diff --name-only HEAD~1 | \
+            grep -E "workflows/.+-container-build.yaml|Makefile|bundle/|config/|go.mod|go.sum|.+\.go|docker/|\.dockerignore" | \
+            grep -v -E ".+_test.go|/.rhdh/")";
+          echo "Changed files for this commit:"
+          echo "=============================="
+          echo "$CHANGES"
+          echo "=============================="
+          {
+            echo 'CHANGES<<EOF'
+            echo $CHANGES
+            echo EOF
+          } >> "$GITHUB_ENV"
+
       - name: Get the last commit short SHA
+        # run this stage only if there are changes that match the includes and not the excludes
+        if: ${{ env.CHANGES != '' }}
         run: |
           SHORT_SHA=$(git rev-parse --short HEAD)
           echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
@@ -50,11 +70,15 @@ jobs:
           echo "BASE_VERSION=$BASE_VERSION" >> $GITHUB_ENV
 
       - name: Setup Go
+        # run this stage only if there are changes that match the includes and not the excludes
+        if: ${{ env.CHANGES != '' }}
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:
           go-version-file: 'go.mod'
 
       - name: Login to quay.io
+        # run this stage only if there are changes that match the includes and not the excludes
+        if: ${{ env.CHANGES != '' }}
         uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -62,6 +86,8 @@ jobs:
           password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Build and push operator, bundle, and catalog images
+        # run this stage only if there are changes that match the includes and not the excludes
+        if: ${{ env.CHANGES != '' }}
         run: |
           # install skopeo, podman
           sudo apt-get -y update; sudo apt-get -y install skopeo podman

--- a/.github/workflows/next-container-build.yaml
+++ b/.github/workflows/next-container-build.yaml
@@ -42,27 +42,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      # check changes in this commit for regex include and exclude matches; pipe to an env var
-      - name: Check for changes to build
-        run: |
-          # don't fail if nothing returned by grep
-          set +e 
-          CHANGES="$(git diff --name-only HEAD~1 | \
-            grep -E "workflows/.+-container-build.yaml|Makefile|bundle/|config/|go.mod|go.sum|.+\.go|docker/|\.dockerignore" | \
-            grep -v -E ".+_test.go|/.rhdh/")";
-          echo "Changed files for this commit:"
-          echo "=============================="
-          echo "$CHANGES"
-          echo "=============================="
-          {
-            echo 'CHANGES<<EOF'
-            echo $CHANGES
-            echo EOF
-          } >> "$GITHUB_ENV"
-
       - name: Get the last commit short SHA
-        # run this stage only if there are changes that match the includes and not the excludes
-        if: ${{ env.CHANGES != '' }}
         run: |
           SHORT_SHA=$(git rev-parse --short HEAD)
           echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
@@ -70,15 +50,11 @@ jobs:
           echo "BASE_VERSION=$BASE_VERSION" >> $GITHUB_ENV
 
       - name: Setup Go
-        # run this stage only if there are changes that match the includes and not the excludes
-        if: ${{ env.CHANGES != '' }}
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:
           go-version-file: 'go.mod'
 
       - name: Login to quay.io
-        # run this stage only if there are changes that match the includes and not the excludes
-        if: ${{ env.CHANGES != '' }}
         uses: docker/login-action@e92390c5fb421da1463c202d546fed0ec5c39f20 # v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -86,8 +62,6 @@ jobs:
           password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Build and push operator, bundle, and catalog images
-        # run this stage only if there are changes that match the includes and not the excludes
-        if: ${{ env.CHANGES != '' }}
         run: |
           # install skopeo, podman
           sudo apt-get -y update; sudo apt-get -y install skopeo podman

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -28,42 +28,18 @@ jobs:
         name: Checkout ${{ matrix.branch }} branch
         run: git switch ${{ matrix.branch }}
 
-      # check changes in this commit for regex include and exclude matches; pipe to an env var
-      - name: Check for changes to build
-        run: |
-          # don't fail if nothing returned by grep
-          set +e 
-          CHANGES="$(git diff --name-only HEAD~1 | \
-            grep -E "workflows/.+-container-build.yaml|Makefile|bundle/|config/|go.mod|go.sum|.+\.go|docker/|\.dockerignore" | \
-            grep -v -E ".+_test.go|/.rhdh/")";
-          echo "Changed files for this commit:"
-          echo "=============================="
-          echo "$CHANGES"
-          echo "=============================="
-          {
-            echo 'CHANGES<<EOF'
-            echo $CHANGES
-            echo EOF
-          } >> "$GITHUB_ENV"
-
       - name: Setup Go
-        # run this stage only if there are changes that match the includes and not the excludes
-        if: ${{ env.CHANGES != '' }}
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5
         with:
           go-version-file: 'go.mod'
 
       - name: Determine built operator image
-        # run this stage only if there are changes that match the includes and not the excludes
-        if: ${{ env.CHANGES != '' }}
         run: |
           SHORT_SHA=$(git rev-parse --short HEAD)
           BASE_VERSION=$(grep -E "^VERSION \?=" Makefile | sed -r -e "s/.+= //") # 0.1.0
           echo "OPERATOR_IMAGE=quay.io/janus-idp/operator:${BASE_VERSION}-${SHORT_SHA}" >> $GITHUB_ENV
 
       - name: Wait until image exists in registry or timeout is reached
-        # run this stage only if there are changes that match the includes and not the excludes
-        if: ${{ env.CHANGES != '' }}
         timeout-minutes: 10
         run: |
           echo "Waiting until operator image is found or timeout expires: ${{ env.OPERATOR_IMAGE }}..."
@@ -74,15 +50,11 @@ jobs:
           echo "... operator image found: ${{ env.OPERATOR_IMAGE }}."
 
       - name: Start Minikube
-        # run this stage only if there are changes that match the includes and not the excludes
-        if: ${{ env.CHANGES != '' }}
         uses: medyagh/setup-minikube@317d92317e473a10540357f1f4b2878b80ee7b95 # v0.0.16
         with:
           addons: ingress
 
       - name: Run E2E tests
-        # run this stage only if there are changes that match the includes and not the excludes
-        if: ${{ env.CHANGES != '' }}
         env:
           BACKSTAGE_OPERATOR_TESTS_PLATFORM: minikube
           IMG: ${{ env.OPERATOR_IMAGE }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -35,19 +35,12 @@ jobs:
 
       - name: Determine built operator image
         run: |
-          SHORT_SHA=$(git rev-parse --short HEAD)
-          BASE_VERSION=$(grep -E "^VERSION \?=" Makefile | sed -r -e "s/.+= //") # 0.1.0
-          echo "OPERATOR_IMAGE=quay.io/janus-idp/operator:${BASE_VERSION}-${SHORT_SHA}" >> $GITHUB_ENV
-
-      - name: Wait until image exists in registry or timeout is reached
-        timeout-minutes: 10
-        run: |
-          echo "Waiting until operator image is found or timeout expires: ${{ env.OPERATOR_IMAGE }}..."
-          until ${CONTAINER_ENGINE} image pull "${{ env.OPERATOR_IMAGE }}"; do
-            sleep 2
-            echo ...
-          done
-          echo "... operator image found: ${{ env.OPERATOR_IMAGE }}."
+          latestNext="next"
+          # for main branch, use next tags; for 1.x branches, use :latest tags
+          if [[ $(git rev-parse --abbrev-ref HEAD) != "main" ]]; then
+            latestNext="latest" 
+          fi
+          echo "OPERATOR_IMAGE=quay.io/janus-idp/operator:${latestNext}" >> $GITHUB_ENV
 
       - name: Start Minikube
         uses: medyagh/setup-minikube@317d92317e473a10540357f1f4b2878b80ee7b95 # v0.0.16


### PR DESCRIPTION
## Description
I realized that some nightly jobs ([example](https://github.com/janus-idp/operator/actions/runs/8607997036/job/23589525220)) could be skipped, but they should have run actually.
To determine if container images needed to be built upon a push, we were looking at the diff between `HEAD` and `HEAD~1`. The problem is that, if there were some additional changes pushed in, say`HEAD~2`, the job would still be skipped even if those changes were relevant for the container image workflow. And this is also why the E2E tests would be skipped.

In this PR, I'm suggesting we always build container images upon any push to the `main` or release branches, and the E2E would always run against the container images built for the most recent commit.
This should help have meaningful E2E tests that always run against the most recent commit.
And it also makes it easy to re-run and reproduce potential failures with the E2E tests.

Note that this does not change container builds for PRs, which may still be skipped depending on the changes.

## Which issue(s) does this PR fix or relate to
&mdash;

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.csv.yaml`](../.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file accordingly

## How to test changes / Special notes to the reviewer
We'll see this in action after this PR is merged in.
