### PR TITLE
feat: tagRelease.sh bump versions in 1.1.x for 1.1 release

### DIFF
--- a/.rhdh/bundle/manifests/rhdh-operator.csv.yaml
+++ b/.rhdh/bundle/manifests/rhdh-operator.csv.yaml
@@ -43,7 +43,7 @@ metadata:
     repository: https://gitlab.cee.redhat.com/rhidp/rhdh/
     support: Red Hat
     skipRange: '>=1.1.0 <1.2.0'
-  name: rhdh-operator.v1.1.2
+  name: rhdh-operator.v1.1.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -348,5 +348,5 @@ spec:
   provider:
     name: Red Hat Inc.
     url: https://www.redhat.com/
-  version: 1.1.2
+  version: 1.1.3
   replaces: rhdh-operator.v1.1.1

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.1.2
+VERSION ?= 0.1.3
 
 # Using docker or podman to build and push images
 CONTAINER_ENGINE ?= docker

--- a/bundle/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/backstage-operator.clusterserviceversion.yaml
@@ -25,7 +25,7 @@ metadata:
     operatorframework.io/suggested-namespace: backstage-system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: backstage-operator.v0.1.2
+  name: backstage-operator.v0.1.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -221,7 +221,7 @@ spec:
                   value: quay.io/fedora/postgresql-15:latest
                 - name: RELATED_IMAGE_backstage
                   value: quay.io/janus-idp/backstage-showcase:latest
-                image: quay.io/janus-idp/operator:0.1.2
+                image: quay.io/janus-idp/operator:0.1.3
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -326,4 +326,4 @@ spec:
     name: postgresql
   - image: quay.io/janus-idp/backstage-showcase:latest
     name: backstage
-  version: 0.1.2
+  version: 0.1.3


### PR DESCRIPTION
Signed-off-by: RHDH Build (rhdh-bot) <rhdh-bot@redhat.com>
