### PR TITLE
change internal object name to "backstage-<cr-name>"

### DIFF
--- a/examples/bs-existing-secret.yaml
+++ b/examples/bs-existing-secret.yaml
@@ -17,4 +17,4 @@ stringData:
   POSTGRES_PORT: "5432"
   POSTGRES_USER: postgres
   POSTGRESQL_ADMIN_PASSWORD: admin123
-  POSTGRES_HOST: bs-existing-secret-backstage-db
+  POSTGRES_HOST: backstage-db-bs-existing-secret

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -48,7 +48,7 @@ func GenerateLabel(labels *map[string]string, name string, value string) {
 
 // GenerateRuntimeObjectName generates name using BackstageCR name and objectType which is ConfigObject Key without '.yaml' (like 'deployment')
 func GenerateRuntimeObjectName(backstageCRName string, objectType string) string {
-	return fmt.Sprintf("%s-%s", backstageCRName, objectType)
+	return fmt.Sprintf("%s-%s", objectType, backstageCRName)
 }
 
 // GenerateVolumeNameFromCmOrSecret generates volume name for mounting ConfigMap or Secret


### PR DESCRIPTION
Swapped managed object names from "<CR-name>-backstage" to "backstage-<CR-name>" to make it compatible with 1.1 OOTB

Fixes https://github.com/janus-idp/operator/issues/355
Fixes https://issues.redhat.com/browse/RHIDP-2278