### PR TITLE
Setup go-imports-organizer and organize Go imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,10 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
+.PHONY: fmt
+fmt: ## Run go fmt verifications
+	hack/verify-gofmt.sh
+
 fmt_license: addlicense ## Ensure the license header is set on all files
 	$(ADDLICENSE) -v -f license_header.txt $$(find . -not -path '*/\.*' -name '*.go')
 	$(ADDLICENSE) -v -f license_header.txt $$(find . -name '*ockerfile')

--- a/Makefile
+++ b/Makefile
@@ -135,12 +135,12 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: manifests generate fmt vet envtest ## Run tests. We need LOCALBIN=$(LOCALBIN) to get correct default-config path
+test: manifests generate verify-imports fmt vet envtest ## Run tests. We need LOCALBIN=$(LOCALBIN) to get correct default-config path
 	mkdir -p $(LOCALBIN)/default-config && cp config/manager/$(CONF_DIR)/* $(LOCALBIN)/default-config
 	LOCALBIN=$(LOCALBIN) KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $(PKGS) -coverprofile cover.out
 
 .PHONY: integration-test
-integration-test: ginkgo manifests generate fmt vet envtest ## Run integration_tests. We need LOCALBIN=$(LOCALBIN) to get correct default-config path
+integration-test: ginkgo manifests generate verify-imports fmt vet envtest ## Run integration_tests. We need LOCALBIN=$(LOCALBIN) to get correct default-config path
 	mkdir -p $(LOCALBIN)/default-config && cp config/manager/$(CONF_DIR)/* $(LOCALBIN)/default-config
 	LOCALBIN=$(LOCALBIN) KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" $(GINKGO) -v -r $(ARGS) integration_tests
 
@@ -148,11 +148,11 @@ integration-test: ginkgo manifests generate fmt vet envtest ## Run integration_t
 ##@ Build
 
 .PHONY: build
-build: generate fmt vet ## Build manager binary.
+build: generate verify-imports fmt vet ## Build manager binary.
 	go build -o bin/manager main.go
 
 .PHONY: run
-run: manifests generate fmt vet build ## Run a controller from your host.
+run: manifests generate verify-imports fmt vet build ## Run a controller from your host.
 	cd $(LOCALBIN) && mkdir -p default-config && cp ../config/manager/$(CONF_DIR)/* default-config && ./manager
 
 # by default images expire from quay registry after 14 days

--- a/controllers/backstage_controller.go
+++ b/controllers/backstage_controller.go
@@ -19,35 +19,27 @@ import (
 	"fmt"
 	"reflect"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
-	"k8s.io/apimachinery/pkg/types"
-
 	openshift "github.com/openshift/api/route/v1"
 
-	"k8s.io/apimachinery/pkg/api/meta"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	corev1 "k8s.io/api/core/v1"
-
-	appsv1 "k8s.io/api/apps/v1"
-
-	"redhat-developer/red-hat-developer-hub-operator/pkg/model"
-
 	bs "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
-
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	"redhat-developer/red-hat-developer-hub-operator/pkg/model"
 )
 
 var watchedConfigSelector = metav1.LabelSelector{

--- a/controllers/preprocessor_test.go
+++ b/controllers/preprocessor_test.go
@@ -17,14 +17,16 @@ package controller
 import (
 	"context"
 	"os"
-	"redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
-	"redhat-developer/red-hat-developer-hub-operator/pkg/model"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/stretchr/testify/assert"
+
+	"redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
+	"redhat-developer/red-hat-developer-hub-operator/pkg/model"
 )
 
 func updateConfigMap(t *testing.T) BackstageReconciler {

--- a/controllers/spec_preprocessor.go
+++ b/controllers/spec_preprocessor.go
@@ -20,18 +20,14 @@ import (
 	"os"
 	"strconv"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	bs "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
-
 	"redhat-developer/red-hat-developer-hub-operator/pkg/model"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 const AutoSyncEnvVar = "EXT_CONF_SYNC_backstage"

--- a/goio.yaml
+++ b/goio.yaml
@@ -1,0 +1,26 @@
+excludes:
+  - matchtype: name
+    regexp: ^\.git$
+  - matchtype: name
+    regexp: ^vendor$
+groups:
+  - description: standard
+    matchorder: 3
+    regexp:
+      - ^[a-zA-Z0-9\/]+$
+  - description: kubernetes
+    matchorder: 1
+    regexp:
+      - ^k8s\.io|^sigs\.k8s\.io
+  - description: openshift
+    matchorder: 2
+    regexp:
+      - ^github\.com\/openshift
+  - description: other
+    matchorder: 4
+    regexp:
+      - '[a-zA-Z0-9]+\.[a-zA-Z0-9]+/'
+  - description: module
+    matchorder: 0
+    regexp:
+      - "%{module}%"

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+function list_go_src_files() {
+	find . -not \( \
+		\( \
+		-wholename './_output' \
+		-o -wholename './.*' \
+		-o -wholename '*/vendor/*' \
+		\) -prune \
+	\) -name '*.go' | sort -u
+}
+
+
+bad_files=$(list_go_src_files | xargs gofmt -s -l)
+if [[ -n "${bad_files}" ]]; then
+        echo "!!! gofmt needs to be run on the listed files"
+        echo "${bad_files}"
+        echo "Try running 'gofmt -s -w [path]'"
+        exit 1
+fi

--- a/integration_tests/config-refresh_test.go
+++ b/integration_tests/config-refresh_test.go
@@ -17,24 +17,20 @@ package integration_tests
 import (
 	"context"
 	"fmt"
-	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
 	"strings"
 	"time"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	corev1 "k8s.io/api/core/v1"
-
 	appsv1 "k8s.io/api/apps/v1"
-
-	"redhat-developer/red-hat-developer-hub-operator/pkg/model"
-
-	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
-
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
+	"redhat-developer/red-hat-developer-hub-operator/pkg/model"
+	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
 )
 
 var _ = When("create backstage with external configuration", func() {

--- a/integration_tests/cr-config_test.go
+++ b/integration_tests/cr-config_test.go
@@ -18,24 +18,18 @@ import (
 	"context"
 	"time"
 
-	corev1 "k8s.io/api/core/v1"
-
-	"k8s.io/utils/ptr"
-
-	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
-
 	appsv1 "k8s.io/api/apps/v1"
-
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	"redhat-developer/red-hat-developer-hub-operator/pkg/model"
-
-	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
-
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
+	"redhat-developer/red-hat-developer-hub-operator/pkg/model"
+	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
 )
 
 var _ = When("create backstage with CR configured", func() {

--- a/integration_tests/db_test.go
+++ b/integration_tests/db_test.go
@@ -19,23 +19,18 @@ import (
 	"fmt"
 	"time"
 
-	"redhat-developer/red-hat-developer-hub-operator/pkg/model"
-
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/utils/ptr"
-
-	corev1 "k8s.io/api/core/v1"
-
 	appsv1 "k8s.io/api/apps/v1"
-
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
-
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
+	"redhat-developer/red-hat-developer-hub-operator/pkg/model"
 )
 
 var _ = When("create backstage with CR configured", func() {

--- a/integration_tests/default-config_test.go
+++ b/integration_tests/default-config_test.go
@@ -19,21 +19,17 @@ import (
 	"fmt"
 	"time"
 
-	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
-
-	"redhat-developer/red-hat-developer-hub-operator/pkg/model"
-
 	appsv1 "k8s.io/api/apps/v1"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
-
 	corev1 "k8s.io/api/core/v1"
-
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
+	"redhat-developer/red-hat-developer-hub-operator/pkg/model"
+	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
 )
 
 var _ = When("create default backstage", func() {

--- a/integration_tests/matchers.go
+++ b/integration_tests/matchers.go
@@ -17,9 +17,10 @@ package integration_tests
 import (
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+
 	"github.com/onsi/gomega/format"
 	"github.com/onsi/gomega/types"
-	corev1 "k8s.io/api/core/v1"
 )
 
 // Matcher for Container VolumeMounts

--- a/integration_tests/rhdh-config_test.go
+++ b/integration_tests/rhdh-config_test.go
@@ -18,19 +18,16 @@ import (
 	"context"
 	"time"
 
-	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
-
 	appsv1 "k8s.io/api/apps/v1"
-
-	"redhat-developer/red-hat-developer-hub-operator/pkg/model"
-
-	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
+	"redhat-developer/red-hat-developer-hub-operator/pkg/model"
+	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
 )
 
 var _ = When("create default backstage", func() {

--- a/integration_tests/route_test.go
+++ b/integration_tests/route_test.go
@@ -16,19 +16,18 @@ package integration_tests
 
 import (
 	"context"
-	"redhat-developer/red-hat-developer-hub-operator/pkg/model"
 	"time"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	openshift "github.com/openshift/api/route/v1"
 
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
-
-	"k8s.io/apimachinery/pkg/types"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
+	"redhat-developer/red-hat-developer-hub-operator/pkg/model"
 )
 
 var _ = When("create default backstage", func() {

--- a/integration_tests/suite_test.go
+++ b/integration_tests/suite_test.go
@@ -18,45 +18,35 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strconv"
-
-	"k8s.io/apimachinery/pkg/api/errors"
-
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	"k8s.io/utils/ptr"
-
-	openshift "github.com/openshift/api/route/v1"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-
-	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
-
-	corev1 "k8s.io/api/core/v1"
-
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	controller "redhat-developer/red-hat-developer-hub-operator/controllers"
-
-	ctrl "sigs.k8s.io/controller-runtime"
-
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
-
-	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
-
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	openshift "github.com/openshift/api/route/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
+	controller "redhat-developer/red-hat-developer-hub-operator/controllers"
+	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/integration_tests/utils.go
+++ b/integration_tests/utils.go
@@ -21,17 +21,16 @@ import (
 	"os"
 	"path/filepath"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/tools/remotecommand"
-
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	//. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	//. "github.com/onsi/ginkgo/v2"
 )
 
 func generateConfigMap(ctx context.Context, k8sClient client.Client, name string, namespace string, data, labels map[string]string, annotations map[string]string) string {

--- a/main.go
+++ b/main.go
@@ -20,24 +20,21 @@ import (
 	"flag"
 	"os"
 
-	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
-	// to ensure that exec-entrypoint and run can make use of them.
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/discovery"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
+	openshift "github.com/openshift/api/route/v1"
+
 	backstageiov1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
 	controller "redhat-developer/red-hat-developer-hub-operator/controllers"
-
-	openshift "github.com/openshift/api/route/v1"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/pkg/model/appconfig.go
+++ b/pkg/model/appconfig.go
@@ -18,12 +18,11 @@ import (
 	"path/filepath"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
 	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
-
-	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type AppConfigFactory struct{}

--- a/pkg/model/appconfig_test.go
+++ b/pkg/model/appconfig_test.go
@@ -16,17 +16,15 @@ package model
 
 import (
 	"context"
-
-	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
-
-	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
-
-	corev1 "k8s.io/api/core/v1"
-
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/stretchr/testify/assert"
+
+	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
+	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
 )
 
 var (

--- a/pkg/model/configmapenvs.go
+++ b/pkg/model/configmapenvs.go
@@ -15,12 +15,12 @@
 package model
 
 import (
-	"redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
-	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
+	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
 )
 
 type ConfigMapEnvsFactory struct{}

--- a/pkg/model/configmapenvs_test.go
+++ b/pkg/model/configmapenvs_test.go
@@ -18,15 +18,13 @@ import (
 	"context"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
-	corev1 "k8s.io/api/core/v1"
+	"github.com/stretchr/testify/assert"
 
 	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDefaultConfigMapEnvFrom(t *testing.T) {

--- a/pkg/model/configmapfiles.go
+++ b/pkg/model/configmapfiles.go
@@ -16,12 +16,11 @@ package model
 
 import (
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
 	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
-
-	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type ConfigMapFilesFactory struct{}

--- a/pkg/model/configmapfiles_test.go
+++ b/pkg/model/configmapfiles_test.go
@@ -16,14 +16,13 @@ package model
 
 import (
 	"context"
-
-	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
+	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"testing"
-
 	"github.com/stretchr/testify/assert"
+
+	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
 )
 
 var (

--- a/pkg/model/db-secret.go
+++ b/pkg/model/db-secret.go
@@ -17,11 +17,11 @@ package model
 import (
 	"strconv"
 
-	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
-	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
-
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
+	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
 )
 
 type DbSecretFactory struct{}

--- a/pkg/model/db-secret_test.go
+++ b/pkg/model/db-secret_test.go
@@ -19,13 +19,12 @@ import (
 	"fmt"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
-	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/stretchr/testify/assert"
+
+	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
 )
 
 var dbSecretBackstage = &bsv1alpha1.Backstage{

--- a/pkg/model/db-service.go
+++ b/pkg/model/db-service.go
@@ -17,11 +17,11 @@ package model
 import (
 	"fmt"
 
-	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
-	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
-
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
+	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
 )
 
 type DbServiceFactory struct{}

--- a/pkg/model/db-statefulset.go
+++ b/pkg/model/db-statefulset.go
@@ -18,13 +18,12 @@ import (
 	"fmt"
 	"os"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
 	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
-
-	appsv1 "k8s.io/api/apps/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const LocalDbImageEnvVar = "RELATED_IMAGE_postgresql"

--- a/pkg/model/db-statefulset_test.go
+++ b/pkg/model/db-statefulset_test.go
@@ -20,14 +20,12 @@ import (
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
-	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/stretchr/testify/assert"
+
+	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
 )
 
 var dbStatefulSetBackstage = &bsv1alpha1.Backstage{

--- a/pkg/model/deployment.go
+++ b/pkg/model/deployment.go
@@ -18,16 +18,13 @@ import (
 	"fmt"
 	"os"
 
-	"k8s.io/utils/ptr"
-
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
-
 	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
-
-	appsv1 "k8s.io/api/apps/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const BackstageImageEnvVar = "RELATED_IMAGE_backstage"

--- a/pkg/model/deployment_test.go
+++ b/pkg/model/deployment_test.go
@@ -18,13 +18,12 @@ import (
 	"context"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
-	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/stretchr/testify/assert"
+
+	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
 )
 
 var deploymentTestBackstage = bsv1alpha1.Backstage{

--- a/pkg/model/dynamic-plugins.go
+++ b/pkg/model/dynamic-plugins.go
@@ -19,12 +19,11 @@ import (
 	"os"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
 	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
-
-	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const dynamicPluginInitContainerName = "install-dynamic-plugins"

--- a/pkg/model/dynamic-plugins_test.go
+++ b/pkg/model/dynamic-plugins_test.go
@@ -16,17 +16,16 @@ package model
 
 import (
 	"context"
-	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
 	"testing"
-
-	"k8s.io/utils/ptr"
-
-	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/stretchr/testify/assert"
+
+	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
+	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
 )
 
 var testDynamicPluginsBackstage = bsv1alpha1.Backstage{

--- a/pkg/model/interfaces.go
+++ b/pkg/model/interfaces.go
@@ -15,10 +15,10 @@
 package model
 
 import (
-	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
-
 	appsv1 "k8s.io/api/apps/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
 )
 
 // Registered Object configuring Backstage runtime model

--- a/pkg/model/model_tests.go
+++ b/pkg/model/model_tests.go
@@ -19,13 +19,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"k8s.io/utils/ptr"
-
 	corev1 "k8s.io/api/core/v1"
-
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/utils/ptr"
 
 	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
 )

--- a/pkg/model/route.go
+++ b/pkg/model/route.go
@@ -15,11 +15,12 @@
 package model
 
 import (
-	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
-	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	openshift "github.com/openshift/api/route/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
+	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
 )
 
 type BackstageRouteFactory struct{}

--- a/pkg/model/route_test.go
+++ b/pkg/model/route_test.go
@@ -18,15 +18,14 @@ import (
 	"context"
 	"testing"
 
-	openshift "github.com/openshift/api/route/v1"
-
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
+	openshift "github.com/openshift/api/route/v1"
 
 	"github.com/stretchr/testify/assert"
+
+	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
 )
 
 func TestDefaultRoute(t *testing.T) {

--- a/pkg/model/runtime.go
+++ b/pkg/model/runtime.go
@@ -23,14 +23,11 @@ import (
 	"sort"
 
 	corev1 "k8s.io/api/core/v1"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
-
 	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
 )
 

--- a/pkg/model/runtime_test.go
+++ b/pkg/model/runtime_test.go
@@ -17,17 +17,15 @@ package model
 import (
 	"context"
 	"fmt"
-
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+
+	"github.com/stretchr/testify/assert"
 
 	"redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
 	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestIfEmptyObjectsContainTypeinfo(t *testing.T) {

--- a/pkg/model/secretenvs.go
+++ b/pkg/model/secretenvs.go
@@ -15,13 +15,13 @@
 package model
 
 import (
-	"redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
-	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
-
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
+	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
 )
 
 type SecretEnvsFactory struct{}

--- a/pkg/model/secretfiles.go
+++ b/pkg/model/secretfiles.go
@@ -18,13 +18,12 @@ import (
 	"fmt"
 
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
 	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
-
-	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type SecretFilesFactory struct{}

--- a/pkg/model/secretfiles_test.go
+++ b/pkg/model/secretfiles_test.go
@@ -18,13 +18,12 @@ import (
 	"context"
 	"testing"
 
-	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
-
-	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/stretchr/testify/assert"
+
+	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
+	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
 )
 
 var (

--- a/pkg/model/service.go
+++ b/pkg/model/service.go
@@ -17,11 +17,11 @@ package model
 import (
 	"fmt"
 
-	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
-	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
-
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	bsv1alpha1 "redhat-developer/red-hat-developer-hub-operator/api/v1alpha1"
+	"redhat-developer/red-hat-developer-hub-operator/pkg/utils"
 )
 
 type BackstageServiceFactory struct{}

--- a/pkg/utils/pod-mutator.go
+++ b/pkg/utils/pod-mutator.go
@@ -17,9 +17,8 @@ package utils
 import (
 	"path/filepath"
 
-	"k8s.io/utils/ptr"
-
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 )
 
 const (

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -24,10 +24,9 @@ import (
 	"regexp"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/discovery"
 	ctrl "sigs.k8s.io/controller-runtime"
-
-	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 const maxK8sResourceNameLength = 63

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -24,10 +24,10 @@ import (
 	"testing"
 	"time"
 
-	"redhat-developer/red-hat-developer-hub-operator/tests/helper"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"redhat-developer/red-hat-developer-hub-operator/tests/helper"
 )
 
 const (

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -21,10 +21,10 @@ import (
 	"strconv"
 	"time"
 
-	"redhat-developer/red-hat-developer-hub-operator/tests/helper"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"redhat-developer/red-hat-developer-hub-operator/tests/helper"
 )
 
 var _ = Describe("Backstage Operator E2E", func() {

--- a/tests/helper/helper_backstage.go
+++ b/tests/helper/helper_backstage.go
@@ -20,12 +20,13 @@ import (
 	"io"
 	"net/http"
 	"os/exec"
-	"redhat-developer/red-hat-developer-hub-operator/pkg/model"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
+
+	"redhat-developer/red-hat-developer-hub-operator/pkg/model"
 )
 
 type ApiEndpointTest struct {

--- a/tests/helper/utils.go
+++ b/tests/helper/utils.go
@@ -23,11 +23,12 @@ import (
 	"strconv"
 	"strings"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/discovery"
 	ctrl "sigs.k8s.io/controller-runtime"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var letterRunes = []rune("abcdefghijklmnopqrstuvwxyz0123456789")


### PR DESCRIPTION
This is what it would look like to implement and run the go-imports-organizer on this project. Please note that I have setup the dependencies to be vendored to support not having each user install the go-imports-organizer as a standalone tool