### PR TITLE
Fix the RBAC permissions of the Operator in the RHDH CSV

### DIFF
--- a/.github/workflows/pr-bundle-diff-checks.yaml
+++ b/.github/workflows/pr-bundle-diff-checks.yaml
@@ -97,3 +97,10 @@ jobs:
               repo: context.repo.repo,
               body: '⚠️ <b>Files changed in bundle generation!</b><br/><br/>Those changes to the operator bundle manifests should have been pushed automatically to your PR branch.<br/>You might also need to manually update the [`.rhdh/bundle/manifests/rhdh-operator.csv.yaml`](${{ env.GH_BLOB_VIEWER_BASE_URL }}/.rhdh/bundle/manifests/rhdh-operator.csv.yaml) CSV file accordingly.'
             })
+
+      - name: Check if the CSV for RHDH needs to be updated
+        run: |
+          echo "Checking that the RBAC roles of the downstream RHDH operator are not out of sync with the upstream CSV..."
+          diff -U 1 \
+            <(yq '.spec.install.spec.clusterPermissions' bundle/manifests/backstage-operator.clusterserviceversion.yaml | grep -v 'serviceAccountName: ') \
+            <(yq '.spec.install.spec.clusterPermissions' .rhdh/bundle/manifests/rhdh-operator.csv.yaml | grep -v 'serviceAccountName: ')

--- a/.rhdh/bundle/manifests/rhdh-operator.csv.yaml
+++ b/.rhdh/bundle/manifests/rhdh-operator.csv.yaml
@@ -81,17 +81,33 @@ spec:
           - ""
           resources:
           - configmaps
-          - persistentvolumeclaims
-          - persistentvolumes
-          - secrets
           - services
           verbs:
           - create
           - delete
           - get
           - list
+          - patch
           - update
           - watch
+        - apiGroups:
+          - ""
+          resources:
+          - persistentvolumeclaims
+          - persistentvolumes
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - delete
+          - patch
+          - update
         - apiGroups:
           - apps
           resources:
@@ -101,6 +117,7 @@ spec:
           - delete
           - get
           - list
+          - patch
           - update
           - watch
         - apiGroups:
@@ -112,6 +129,7 @@ spec:
           - delete
           - get
           - list
+          - patch
           - update
           - watch
         - apiGroups:
@@ -144,11 +162,13 @@ spec:
           - route.openshift.io
           resources:
           - routes
+          - routes/custom-host
           verbs:
           - create
           - delete
           - get
           - list
+          - patch
           - update
           - watch
         - apiGroups:


### PR DESCRIPTION
## Description
There was a difference in the RBAC permissions of the operator between the CSV used for RHDH (https://github.com/janus-idp/operator/blob/main/.rhdh/bundle/manifests/rhdh-operator.csv.yaml) and the upstream one (https://github.com/janus-idp/operator/blob/main/bundle/manifests/backstage-operator.clusterserviceversion.yaml).
This causes issues like the one reported in #360.

## Which issue(s) does this PR fix or relate to

- Fixes https://github.com/janus-idp/operator/issues/360
- Fixes https://issues.redhat.com/browse/RHIDP-2325

## PR acceptance criteria

- [x] Tests
- [ ] Documentation
- [x] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.csv.yaml`](../.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file accordingly

## How to test changes / Special notes to the reviewer

Diff should only be about the service account name:

```diff
$ diff -U 1 \
    <(yq '.spec.install.spec.clusterPermissions' bundle/manifests/backstage-operator.clusterserviceversion.yaml) \
    <(yq '.spec.install.spec.clusterPermissions' .rhdh/bundle/manifests/rhdh-operator.csv.yaml)

--- /proc/self/fd/11    2024-05-14 16:28:32.538242718 +0200
+++ /proc/self/fd/12    2024-05-14 16:28:32.539242725 +0200
@@ -107,2 +107,2 @@
         - create
-  serviceAccountName: backstage-controller-manager
+  serviceAccountName: rhdh-operator
```

We can retry the repro steps depicted in https://github.com/janus-idp/operator/issues/360 after a new downstream build is done (after this PR merged).