### PR TITLE
[RHIDP-2246] Fix reconciliation issue when referenced ConfigMap/Secret has a dot (`.`) in its name

### DIFF
--- a/examples/rhdh-cr-with-app-configs.yaml
+++ b/examples/rhdh-cr-with-app-configs.yaml
@@ -19,14 +19,9 @@ spec:
       mountPath: /tmp/my-extra-files
       configMaps:
         - name: "my-backstage-extra-files-cm1"
-        # RHIDP-2246: mounting secret or configmap with a '.' in the name
-        - name: "my-extra-file-cm.txt"
       secrets:
         - name: "my-backstage-extra-files-secret1"
           key: secret_file1.txt
-        # RHIDP-2246: mounting secret or configmap with a '.' in the name
-        - name: "my-extra-file-secret.txt"
-          key: extra-file-secret.1
     extraEnvs:
       envs:
         - name: GITHUB_ORG
@@ -191,20 +186,6 @@ data:
 
 ---
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: my-extra-file-cm.txt
-data:
-  my-extra-file-cm-1.txt: |
-    # From ConfigMap with . in its name
-    Hello World
-  my-extra-file-cm-2.txt: |
-    # From ConfigMap with . in its name
-    some:
-      yaml: definition
-
----
-apiVersion: v1
 kind: Secret
 metadata:
   name: my-backstage-extra-files-secret1
@@ -224,15 +205,3 @@ stringData:
     webhookSecret: someWebhookSecret
     privateKey: |
       SomeRsaPrivateKey
-
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: my-extra-file-secret.txt
-stringData:
-  extra-file-secret.1: |
-    # From Secret with . in its name
-    <settings>
-      <somefield>some value</somefield>
-    </setting>

--- a/examples/rhdh-cr-with-app-configs.yaml
+++ b/examples/rhdh-cr-with-app-configs.yaml
@@ -19,9 +19,14 @@ spec:
       mountPath: /tmp/my-extra-files
       configMaps:
         - name: "my-backstage-extra-files-cm1"
+        # RHIDP-2246: mounting secret or configmap with a '.' in the name
+        - name: "my-extra-file-cm.txt"
       secrets:
         - name: "my-backstage-extra-files-secret1"
           key: secret_file1.txt
+        # RHIDP-2246: mounting secret or configmap with a '.' in the name
+        - name: "my-extra-file-secret.txt"
+          key: extra-file-secret.1
     extraEnvs:
       envs:
         - name: GITHUB_ORG
@@ -186,6 +191,20 @@ data:
 
 ---
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-extra-file-cm.txt
+data:
+  my-extra-file-cm-1.txt: |
+    # From ConfigMap with . in its name
+    Hello World
+  my-extra-file-cm-2.txt: |
+    # From ConfigMap with . in its name
+    some:
+      yaml: definition
+
+---
+apiVersion: v1
 kind: Secret
 metadata:
   name: my-backstage-extra-files-secret1
@@ -205,3 +224,15 @@ stringData:
     webhookSecret: someWebhookSecret
     privateKey: |
       SomeRsaPrivateKey
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-extra-file-secret.txt
+stringData:
+  extra-file-secret.1: |
+    # From Secret with . in its name
+    <settings>
+      <somefield>some value</somefield>
+    </setting>

--- a/integration_tests/cr-config_test.go
+++ b/integration_tests/cr-config_test.go
@@ -58,12 +58,15 @@ var _ = When("create backstage with CR configured", func() {
 
 		appConfig1 := generateConfigMap(ctx, k8sClient, "app-config1", ns, map[string]string{"key11": "app:", "key12": "app:"}, nil, nil)
 		appConfig2 := generateConfigMap(ctx, k8sClient, "app-config2", ns, map[string]string{"key21": "app:", "key22": "app:"}, nil, nil)
+		appConfig3 := generateConfigMap(ctx, k8sClient, "app-config3.dot", ns, map[string]string{"key.31": "app31:"}, nil, nil)
 
 		cmFile1 := generateConfigMap(ctx, k8sClient, "cm-file1", ns, map[string]string{"cm11": "11", "cm12": "12"}, nil, nil)
 		cmFile2 := generateConfigMap(ctx, k8sClient, "cm-file2", ns, map[string]string{"cm21": "21", "cm22": "22"}, nil, nil)
+		cmFile3 := generateConfigMap(ctx, k8sClient, "cm-file3.dot", ns, map[string]string{"cm.31": "31"}, nil, nil)
 
 		secretFile1 := generateSecret(ctx, k8sClient, "secret-file1", ns, map[string]string{"sec11": "val11", "sec12": "val12"}, nil, nil)
 		secretFile2 := generateSecret(ctx, k8sClient, "secret-file2", ns, map[string]string{"sec21": "val21", "sec22": "val22"}, nil, nil)
+		secretFile3 := generateSecret(ctx, k8sClient, "secret-file3.dot", ns, map[string]string{"sec.31": "val31", "sec.32": "val22"}, nil, nil)
 
 		cmEnv1 := generateConfigMap(ctx, k8sClient, "cm-env1", ns, map[string]string{"cm11": "11", "cm12": "12"}, nil, nil)
 		cmEnv2 := generateConfigMap(ctx, k8sClient, "cm-env2", ns, map[string]string{"cm21": "21", "cm22": "22"}, nil, nil)
@@ -78,6 +81,7 @@ var _ = When("create backstage with CR configured", func() {
 					ConfigMaps: []bsv1alpha1.ObjectKeyRef{
 						{Name: appConfig1},
 						{Name: appConfig2, Key: "key21"},
+						{Name: appConfig3},
 					},
 				},
 				ExtraFiles: &bsv1alpha1.ExtraFiles{
@@ -85,10 +89,12 @@ var _ = When("create backstage with CR configured", func() {
 					ConfigMaps: []bsv1alpha1.ObjectKeyRef{
 						{Name: cmFile1},
 						{Name: cmFile2, Key: "cm21"},
+						{Name: cmFile3},
 					},
 					Secrets: []bsv1alpha1.ObjectKeyRef{
 						{Name: secretFile1, Key: "sec11"},
 						{Name: secretFile2, Key: "sec21"},
+						{Name: secretFile3, Key: "sec.31"},
 					},
 				},
 				ExtraEnvs: &bsv1alpha1.ExtraEnvs{
@@ -118,38 +124,45 @@ var _ = When("create backstage with CR configured", func() {
 			By("checking if app-config volumes are added to PodSpec")
 			g.Expect(utils.GenerateVolumeNameFromCmOrSecret(appConfig1)).To(BeAddedAsVolumeToPodSpec(podSpec))
 			g.Expect(utils.GenerateVolumeNameFromCmOrSecret(appConfig2)).To(BeAddedAsVolumeToPodSpec(podSpec))
+			g.Expect(utils.GenerateVolumeNameFromCmOrSecret(appConfig3)).To(BeAddedAsVolumeToPodSpec(podSpec))
 
 			By("checking if app-config volumes are mounted to the Backstage container")
 			g.Expect("/my/mount/path/key11").To(BeMountedToContainer(c))
 			g.Expect("/my/mount/path/key12").To(BeMountedToContainer(c))
 			g.Expect("/my/mount/path/key21").To(BeMountedToContainer(c))
 			g.Expect("/my/mount/path/key22").NotTo(BeMountedToContainer(c))
+			g.Expect("/my/mount/path/key.31").To(BeMountedToContainer(c))
 
 			By("checking if app-config args are added to the Backstage container")
 			g.Expect("/my/mount/path/key11").To(BeAddedAsArgToContainer(c))
 			g.Expect("/my/mount/path/key12").To(BeAddedAsArgToContainer(c))
 			g.Expect("/my/mount/path/key21").To(BeAddedAsArgToContainer(c))
 			g.Expect("/my/mount/path/key22").NotTo(BeAddedAsArgToContainer(c))
+			g.Expect("/my/mount/path/key.31").To(BeAddedAsArgToContainer(c))
 
 			By("checking if extra-cm-file volumes are added to PodSpec")
 			g.Expect(utils.GenerateVolumeNameFromCmOrSecret(cmFile1)).To(BeAddedAsVolumeToPodSpec(podSpec))
 			g.Expect(utils.GenerateVolumeNameFromCmOrSecret(cmFile2)).To(BeAddedAsVolumeToPodSpec(podSpec))
+			g.Expect(utils.GenerateVolumeNameFromCmOrSecret(cmFile3)).To(BeAddedAsVolumeToPodSpec(podSpec))
 
 			By("checking if extra-cm-file volumes are mounted to the Backstage container")
 			g.Expect("/my/file/path/cm11").To(BeMountedToContainer(c))
 			g.Expect("/my/file/path/cm12").To(BeMountedToContainer(c))
 			g.Expect("/my/file/path/cm21").To(BeMountedToContainer(c))
 			g.Expect("/my/file/path/cm22").NotTo(BeMountedToContainer(c))
+			g.Expect("/my/file/path/cm.31").To(BeMountedToContainer(c))
 
 			By("checking if extra-secret-file volumes are added to PodSpec")
 			g.Expect(utils.GenerateVolumeNameFromCmOrSecret("secret-file1")).To(BeAddedAsVolumeToPodSpec(podSpec))
 			g.Expect(utils.GenerateVolumeNameFromCmOrSecret("secret-file2")).To(BeAddedAsVolumeToPodSpec(podSpec))
+			g.Expect(utils.GenerateVolumeNameFromCmOrSecret("secret-file3.dot")).To(BeAddedAsVolumeToPodSpec(podSpec))
 
 			By("checking if extra-secret-file volumes are mounted to the Backstage container")
 			g.Expect("/my/file/path/sec11").To(BeMountedToContainer(c))
 			g.Expect("/my/file/path/sec12").NotTo(BeMountedToContainer(c))
 			g.Expect("/my/file/path/sec21").To(BeMountedToContainer(c))
 			g.Expect("/my/file/path/sec22").NotTo(BeMountedToContainer(c))
+			g.Expect("/my/file/path/sec.31").To(BeMountedToContainer(c))
 
 			By("checking if extra-envvars are injected to the Backstage container as EnvFrom")
 			g.Expect("cm-env1").To(BeEnvFromForContainer(c))

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -21,12 +21,16 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"k8s.io/client-go/discovery"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
+
+const maxK8sResourceNameLength = 63
 
 func SetKubeLabels(labels map[string]string, backstageName string) map[string]string {
 	if labels == nil {
@@ -53,7 +57,7 @@ func GenerateRuntimeObjectName(backstageCRName string, objectType string) string
 
 // GenerateVolumeNameFromCmOrSecret generates volume name for mounting ConfigMap or Secret
 func GenerateVolumeNameFromCmOrSecret(cmOrSecretName string) string {
-	return cmOrSecretName
+	return ToKubernetesResourceName(cmOrSecretName)
 }
 
 func BackstageAppLabelValue(backstageName string) string {
@@ -118,4 +122,34 @@ func IsOpenshift() (bool, error) {
 	}
 
 	return false, nil
+}
+
+// ToKubernetesResourceName converts a string into a valid Kubernetes resource name.
+// See https://kubernetes.io/docs/concepts/overview/working-with-objects/names/ for more details about the requirements.
+// It will replace any invalid characters with a dash and drop any leading or trailing dashes.
+// It might return an empty string, as a result of those operations.
+func ToKubernetesResourceName(str string) string {
+	const dash = "-"
+
+	name := strings.ToLower(str)
+
+	// Replace all invalid characters with a dash
+	re := regexp.MustCompile(`[^a-z0-9-]`)
+	name = re.ReplaceAllString(name, dash)
+
+	// Replace consecutive dashes with a single dash
+	reConsecutiveDashes := regexp.MustCompile(`-+`)
+	name = reConsecutiveDashes.ReplaceAllString(name, dash)
+
+	// Truncate to maxK8sResourceNameLength characters if necessary
+	if len(name) > maxK8sResourceNameLength {
+		name = name[:maxK8sResourceNameLength]
+	}
+
+	// Continue trimming leading and trailing dashes if necessary
+	for strings.HasPrefix(name, dash) || strings.HasSuffix(name, dash) {
+		name = strings.Trim(name, dash)
+	}
+
+	return name
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -55,9 +55,14 @@ func GenerateRuntimeObjectName(backstageCRName string, objectType string) string
 	return fmt.Sprintf("%s-%s", objectType, backstageCRName)
 }
 
-// GenerateVolumeNameFromCmOrSecret generates volume name for mounting ConfigMap or Secret
+// GenerateVolumeNameFromCmOrSecret generates volume name for mounting ConfigMap or Secret.
+//
+// It does so by converting the input name to an RFC 1123-compliant value, which is required by Kubernetes,
+// even if the input CM/Secret name can be a valid DNS subdomain.
+//
+// See https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 func GenerateVolumeNameFromCmOrSecret(cmOrSecretName string) string {
-	return ToKubernetesResourceName(cmOrSecretName)
+	return ToRFC1123Label(cmOrSecretName)
 }
 
 func BackstageAppLabelValue(backstageName string) string {
@@ -124,11 +129,10 @@ func IsOpenshift() (bool, error) {
 	return false, nil
 }
 
-// ToKubernetesResourceName converts a string into a valid Kubernetes resource name.
+// ToRFC1123Label converts the given string into a valid Kubernetes label name (RFC 1123-compliant).
 // See https://kubernetes.io/docs/concepts/overview/working-with-objects/names/ for more details about the requirements.
 // It will replace any invalid characters with a dash and drop any leading or trailing dashes.
-// It might return an empty string, as a result of those operations.
-func ToKubernetesResourceName(str string) string {
+func ToRFC1123Label(str string) string {
 	const dash = "-"
 
 	name := strings.ToLower(str)

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,84 @@
+package utils
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation"
+)
+
+func TestToKubernetesResourceName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "should return lowercase",
+			in:   "Lorem-Ipsum",
+			want: "lorem-ipsum",
+		},
+		{
+			name: "should replace invalid characters with a dash",
+			in:   "Kube-root CA.crt",
+			want: "kube-root-ca-crt",
+		},
+		{
+			name: "should remove trailing and leading invalid characters",
+			in:   "_ some/file/ path ?",
+			want: "some-file-path",
+		},
+		{
+			name: "all-numeric string should remain unchanged",
+			in:   "123456789",
+			want: "123456789",
+		},
+		{
+			name: "should return an empty string for input with only invalid characters",
+			in:   "#?@  *&^------ %% --",
+			want: "",
+		},
+		{
+			name: "should truncate up to the maximum length",
+			in:   strings.Repeat("my_file.sh" /* 10 characters*/, 10),
+			want: strings.Repeat("my-file-sh", 6) + "my",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ToKubernetesResourceName(tt.in); got != tt.want {
+				t.Errorf("ToKubernetesResourceName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func FuzzToKubernetesResourceName(f *testing.F) {
+	// seed corpus
+	testcases := []string{"Hello, world", "!12345", ">> .Lorem Ipsum !#"}
+	for _, tc := range testcases {
+		f.Add(tc)
+	}
+	re := regexp.MustCompile(`[a-zA-Z0-9]`)
+	f.Fuzz(func(t *testing.T, in string) {
+		k8sName := ToKubernetesResourceName(in)
+		if len(k8sName) > maxK8sResourceNameLength {
+			t.Errorf("ToKubernetesResourceName produced a string longer than %d characters for %q as input", maxK8sResourceNameLength, in)
+			return
+		}
+		if k8sName == "" {
+			// we should get an empty output if input only consists of invalid characters
+			validChars := re.FindString(in)
+			if validChars != "" {
+				t.Errorf("ToKubernetesResourceName produced an empty string for %q, which contains some valid characters", in)
+			}
+			return
+		}
+		errs := validation.IsDNS1123Label(k8sName)
+		if len(errs) > 0 {
+			t.Errorf("ToKubernetesResourceName produced non-compliant resource name for %q, errors: %s",
+				in, strings.Join(errs, ", "))
+		}
+	})
+}

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,33 +1,21 @@
 package utils
 
 import (
-	"regexp"
-	"strings"
 	"testing"
-
-	"k8s.io/apimachinery/pkg/util/validation"
 )
 
-func TestToKubernetesResourceName(t *testing.T) {
+func TestToRFC1123Label(t *testing.T) {
 	tests := []struct {
 		name string
 		in   string
 		want string
 	}{
-		{
-			name: "should return lowercase",
-			in:   "Lorem-Ipsum",
-			want: "lorem-ipsum",
-		},
+		// The inputs below are all valid names for K8s ConfigMaps or Secrets.
+
 		{
 			name: "should replace invalid characters with a dash",
-			in:   "Kube-root CA.crt",
+			in:   "kube-root-ca.crt",
 			want: "kube-root-ca-crt",
-		},
-		{
-			name: "should remove trailing and leading invalid characters",
-			in:   "_ some/file/ path ?",
-			want: "some-file-path",
 		},
 		{
 			name: "all-numeric string should remain unchanged",
@@ -35,50 +23,16 @@ func TestToKubernetesResourceName(t *testing.T) {
 			want: "123456789",
 		},
 		{
-			name: "should return an empty string for input with only invalid characters",
-			in:   "#?@  *&^------ %% --",
-			want: "",
-		},
-		{
-			name: "should truncate up to the maximum length",
-			in:   strings.Repeat("my_file.sh" /* 10 characters*/, 10),
-			want: strings.Repeat("my-file-sh", 6) + "my",
+			name: "should truncate up to the maximum length and remove leading and trailing dashes",
+			in:   "ppxkgq.df-yyatvyrgjtwivunibicne-bvyyotvonbrtfv-awylmrez.ksvqjw-z.xpgdi", /* 70 characters */
+			want: "ppxkgq-df-yyatvyrgjtwivunibicne-bvyyotvonbrtfv-awylmrez-ksvqjw",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := ToKubernetesResourceName(tt.in); got != tt.want {
-				t.Errorf("ToKubernetesResourceName() = %v, want %v", got, tt.want)
+			if got := ToRFC1123Label(tt.in); got != tt.want {
+				t.Errorf("ToRFC1123Label() = %v, want %v", got, tt.want)
 			}
 		})
 	}
-}
-
-func FuzzToKubernetesResourceName(f *testing.F) {
-	// seed corpus
-	testcases := []string{"Hello, world", "!12345", ">> .Lorem Ipsum !#"}
-	for _, tc := range testcases {
-		f.Add(tc)
-	}
-	re := regexp.MustCompile(`[a-zA-Z0-9]`)
-	f.Fuzz(func(t *testing.T, in string) {
-		k8sName := ToKubernetesResourceName(in)
-		if len(k8sName) > maxK8sResourceNameLength {
-			t.Errorf("ToKubernetesResourceName produced a string longer than %d characters for %q as input", maxK8sResourceNameLength, in)
-			return
-		}
-		if k8sName == "" {
-			// we should get an empty output if input only consists of invalid characters
-			validChars := re.FindString(in)
-			if validChars != "" {
-				t.Errorf("ToKubernetesResourceName produced an empty string for %q, which contains some valid characters", in)
-			}
-			return
-		}
-		errs := validation.IsDNS1123Label(k8sName)
-		if len(errs) > 0 {
-			t.Errorf("ToKubernetesResourceName produced non-compliant resource name for %q, errors: %s",
-				in, strings.Join(errs, ", "))
-		}
-	})
 }


### PR DESCRIPTION
## Description
This PR fixes an issue when a ConfigMap or Secret is referenced in the CR and contains a dot (`.`) in its name. The operator would use the ConfigMap/Secret name as is as the volume name in the Deployment Spec, which could be reported as invalid by Kubernetes.
This PR makes sure to sanitize volume names, such that they are RFC 1123-compliant, as depicted in https://kubernetes.io/docs/concepts/overview/working-with-objects/names/.

## Which issue(s) does this PR fix or relate to

- Fixes https://issues.redhat.com/browse/RHIDP-2246

## PR acceptance criteria

- [x] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.csv.yaml`](../.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file accordingly

## How to test changes / Special notes to the reviewer
See the updated example in [examples/rhdh-cr-with-app-configs.yaml](https://github.com/rm3l/janus-idp-operator/blob/RHIDP-2246--cannot-mount-a-secret-configmap-with-a-.-in-its-name/examples/rhdh-cr-with-app-configs.yaml).
Prior to the changes here, this example would not be reconciled properly. Now it works as expected.
