### PR TITLE
ci: Run Integration Tests as part of PR checks

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -63,6 +63,9 @@ jobs:
         if: ${{ env.CHANGES != '' }}
         run: make test
 
+      - name: Run integration tests
+        run: make integration-test
+
       - name: Run Gosec Security Scanner
         run: make gosec
 


### PR DESCRIPTION
## Description

As the PR title suggests, this allows us to enforce that integration tests are run as part of the PR validation checks.
Currently, we are only running unit tests with `make test`. In the past, `make test` used to cover a lot more via [EnvTest](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/envtest), but this part has been moved to a `make integration-test` target since https://github.com/janus-idp/operator/pull/272).

As I almost always happen to run this target (along with the E2E tests) when reviewing PRs, I think we should enforce those integration tests as part of the automatic PR checks. Unlike the E2E tests, they don't take that long to run and do not require a cluster to run.

## Which issue(s) does this PR fix or relate to

&mdash;

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.csv.yaml`](../.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file accordingly

## How to test changes / Special notes to the reviewer
Job passing: https://github.com/janus-idp/operator/actions/runs/9177666830/job/25235797784?pr=365