### PR TITLE
chore: set `NODE_OPTIONS=--no-node-snapshot` env variable by default

### DIFF
--- a/bundle/manifests/backstage-default-config_v1_configmap.yaml
+++ b/bundle/manifests/backstage-default-config_v1_configmap.yaml
@@ -260,6 +260,8 @@ data:
               env:
                 - name: APP_CONFIG_backend_listen_port
                   value: "7007"
+                - name: NODE_OPTIONS
+                  value: '--no-node-snapshot'
               volumeMounts:
                 - mountPath: /opt/app-root/src/dynamic-plugins-root
                   name: dynamic-plugins-root

--- a/bundle/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/backstage-operator.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2024-05-27T15:07:37Z"
+    createdAt: "2024-05-27T16:06:34Z"
     operatorframework.io/suggested-namespace: backstage-system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/config/manager/default-config/deployment.yaml
+++ b/config/manager/default-config/deployment.yaml
@@ -99,6 +99,8 @@ spec:
           env:
             - name: APP_CONFIG_backend_listen_port
               value: "7007"
+            - name: NODE_OPTIONS
+              value: '--no-node-snapshot'
           volumeMounts:
             - mountPath: /opt/app-root/src/dynamic-plugins-root
               name: dynamic-plugins-root


### PR DESCRIPTION
<!-- 
Thank you for opening a PR! Please take the time to fill in the details below.
-->

## Description
<!--
Please explain the changes you made here.
-->
Now that the RHDH image runs on NodeJS 20, the `NODE_OPTIONS=--no-node-snapshot` environmental variable is required to utilize the backstage scaffolder due to requirements from `isolated-vm`.

References: https://github.com/backstage/backstage/issues/20661
https://github.com/laverdet/isolated-vm?tab=readme-ov-file#requirements

## Which issue(s) does this PR fix or relate to

- Fixes [RHIDP-2436](https://issues.redhat.com/browse/RHIDP-2436)

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.csv.yaml`](../.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file accordingly

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
