### PR TITLE
Fix version number in `skipRange` and `name` fields in base CSV

### DIFF
--- a/config/manifests/bases/backstage-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/backstage-operator.clusterserviceversion.yaml
@@ -6,7 +6,7 @@ metadata:
     capabilities: Seamless Upgrades
     operatorframework.io/suggested-namespace: backstage-system
     skipRange: '>=0.0.1 <0.3.0'
-  name: backstage-operator.v0.2.0
+  name: backstage-operator.v0.3.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}

--- a/config/manifests/bases/backstage-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/backstage-operator.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Seamless Upgrades
     operatorframework.io/suggested-namespace: backstage-system
-    skipRange: '>=0.0.1 <0.2.0'
+    skipRange: '>=0.0.1 <0.3.0'
   name: backstage-operator.v0.2.0
   namespace: placeholder
 spec:


### PR DESCRIPTION
## Description
This fixes the `skipRange` field in the base CSV on the `main` branch.
After rebasing https://github.com/janus-idp/operator/pull/369 onto `main`, I noticed a change to the generated bundle, which should not have occurred there.

## Which issue(s) does this PR fix or relate to

This is a follow-up to https://github.com/janus-idp/operator/pull/375

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.csv.yaml`](../.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file accordingly

## How to test changes / Special notes to the reviewer
<!--
Detailed instructions may help reviewers test this PR quickly and provide quicker feedback.
-->
