### PR TITLE
ci: Run Nightly job against the `1.2.x` branch as well and skip job if operator image has expired

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [ main, 1.1.x ]
+        branch: [ main, 1.2.x, 1.1.x ]
     name: E2E Tests - ${{ matrix.branch }}
     concurrency:
       group: ${{ github.workflow }}-${{ matrix.branch }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -35,19 +35,26 @@ jobs:
 
       - name: Determine built operator image
         run: |
-          latestNext="next"
-          # for main branch, use next tags; for 1.x branches, use :latest tags
-          if [[ $(git rev-parse --abbrev-ref HEAD) != "main" ]]; then
-            latestNext="latest" 
-          fi
-          echo "OPERATOR_IMAGE=quay.io/janus-idp/operator:${latestNext}" >> $GITHUB_ENV
+          echo "OPERATOR_IMAGE=$(make show-img)" >> $GITHUB_ENV
+
+      - name: Check if image exists in remote registry
+        id: operator-image-existence-checker
+        run: |
+          echo "OPERATOR_IMAGE_EXISTS=$(if skopeo inspect "docker://${{ env.OPERATOR_IMAGE }}" > /dev/null; then echo "true"; else echo "false"; fi)" >> $GITHUB_OUTPUT
+
+      - name: Display warning if image was not found
+        if: ${{ steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'false' }}
+        run: |
+          echo "::warning ::Image ${{ env.OPERATOR_IMAGE }} not found for testing the ${{ matrix.branch }} branch. It might have expired. E2E tests will be skipped for ${{ matrix.branch }}."
 
       - name: Start Minikube
+        if: ${{ steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
         uses: medyagh/setup-minikube@317d92317e473a10540357f1f4b2878b80ee7b95 # v0.0.16
         with:
           addons: ingress
 
       - name: Run E2E tests
+        if: ${{ steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
         env:
           BACKSTAGE_OPERATOR_TESTS_PLATFORM: minikube
           IMG: ${{ env.OPERATOR_IMAGE }}


### PR DESCRIPTION
## Description
Now that the `1.2.x` branch has been created, it makes sense to run the nightly jobs against it.
Also, because of our image expiration policy, nightly jobs might fail if the operator image has expired (e.g., because the corresponding branch had not been updated for a long time). Example [here](https://github.com/janus-idp/operator/actions/runs/9342020815/job/25709492555).
In such case, it does not make sense for the nightly job to fail. Instead, this PR makes it display a simple warning message in the Workflow summary.

## Which issue(s) does this PR fix or relate to

&mdash;

## PR acceptance criteria

- [x] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.csv.yaml`](../.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file accordingly

## How to test changes / Special notes to the reviewer
See an example of a Workflow Run here: https://github.com/rm3l/janus-idp-operator/actions/runs/9365256636