### PR TITLE
chore(CI): Skip the Operator Upgrade tests if the image for the current branch has expired

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Run E2E tests (Operator Upgrade path)
         # Testing upgrade from 1.1.x
-        if: ${{ matrix.branch != '1.1.x' }}
+        if: ${{ matrix.branch != '1.1.x' && steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
         env:
           BACKSTAGE_OPERATOR_TESTS_PLATFORM: minikube
           IMG: ${{ env.OPERATOR_IMAGE }}


### PR DESCRIPTION
## Description
This fixes the nightly jobs that have been failing for the past few days. See https://github.com/janus-idp/operator/actions/runs/9705023377/job/26786334075

## PR acceptance criteria

- [x] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.csv.yaml`](../.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file accordingly

## How to test changes / Special notes to the reviewer
Nightly jobs should pass.
