### PR TITLE
[1.2.x] Allow configuring the storage class name for PVCs used by both DB and app

### DIFF
--- a/.rhdh/bundle/manifests/rhdh-operator.csv.yaml
+++ b/.rhdh/bundle/manifests/rhdh-operator.csv.yaml
@@ -56,6 +56,21 @@ spec:
       displayName: Red Hat Developer Hub
       kind: Backstage
       name: backstages.rhdh.redhat.com
+      specDescriptors:
+      - description: Name of the storage class to use for the Persistent Volumes requested
+          by the application. The default storage class name will be used if this
+          field is not specified.
+        displayName: Storage Class for Application volumes
+        path: application.storageClassName
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:StorageClass
+      - description: Name of the storage class to use for the database Persistent
+          Volumes. The default storage class name will be used if this field is not
+          specified.
+        displayName: Storage Class for database volumes
+        path: database.storageClassName
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:StorageClass
       version: v1alpha1
   description: |
     Red Hat Developer Hub is an enterprise-grade platform for building developer portals, containing a supported and opinionated framework. By implementing a unified and open platform designed to maximize developer skills, ease onboarding, and increase development productivity, focus can be centered on what really matters: writing great code. Red Hat Developer Hub also offers Software Templates to simplify the development process, which can reduce friction and frustration for development teams, boosting their productivity and increasing an organization's competitive advantage.

--- a/api/v1alpha1/backstage_types.go
+++ b/api/v1alpha1/backstage_types.go
@@ -70,6 +70,7 @@ type Database struct {
 	// Name of the storage class to use for the database Persistent Volumes.
 	// The default storage class name will be used if this field is not specified.
 	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Storage Class for database volumes",xDescriptors={"urn:alm:descriptor:io.kubernetes:StorageClass"}
 	StorageClassName *string `json:"storageClassName,omitempty"`
 }
 
@@ -122,6 +123,7 @@ type Application struct {
 	// Name of the storage class to use for the Persistent Volumes requested by the application.
 	// The default storage class name will be used if this field is not specified.
 	// +optional
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Storage Class for Application volumes",xDescriptors={"urn:alm:descriptor:io.kubernetes:StorageClass"}
 	StorageClassName *string `json:"storageClassName,omitempty"`
 }
 

--- a/api/v1alpha1/backstage_types.go
+++ b/api/v1alpha1/backstage_types.go
@@ -66,6 +66,11 @@ type Database struct {
 	// "POSTGRESQL_ADMIN_PASSWORD": "rl4s3Fh4ng3M4"
 	// "POSTGRES_HOST": "backstage-psql-bs1"  # For local database, set to "backstage-psql-<CR name>".
 	AuthSecretName string `json:"authSecretName,omitempty"`
+
+	// Name of the storage class to use for the database Persistent Volumes.
+	// The default storage class name will be used if this field is not specified.
+	// +optional
+	StorageClassName *string `json:"storageClassName,omitempty"`
 }
 
 type Application struct {
@@ -113,6 +118,11 @@ type Application struct {
 
 	// Route configuration. Used for OpenShift only.
 	Route *Route `json:"route,omitempty"`
+
+	// Name of the storage class to use for the Persistent Volumes requested by the application.
+	// The default storage class name will be used if this field is not specified.
+	// +optional
+	StorageClassName *string `json:"storageClassName,omitempty"`
 }
 
 type AppConfig struct {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -83,6 +83,11 @@ func (in *Application) DeepCopyInto(out *Application) {
 		in, out := &in.Route, &out.Route
 		*out = new(Route)
 		(*in).DeepCopyInto(*out)
+	}
+	if in.StorageClassName != nil {
+		in, out := &in.StorageClassName, &out.StorageClassName
+		*out = new(string)
+		**out = **in
 	}
 }
 
@@ -213,6 +218,11 @@ func (in *Database) DeepCopyInto(out *Database) {
 	if in.EnableLocalDb != nil {
 		in, out := &in.EnableLocalDb, &out.EnableLocalDb
 		*out = new(bool)
+		**out = **in
+	}
+	if in.StorageClassName != nil {
+		in, out := &in.StorageClassName, &out.StorageClassName
+		*out = new(string)
 		**out = **in
 	}
 }

--- a/bundle/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/backstage-operator.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2024-07-04T10:22:58Z"
+    createdAt: "2024-07-05T09:05:48Z"
     operatorframework.io/suggested-namespace: backstage-system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -36,6 +36,21 @@ spec:
       displayName: Backstage
       kind: Backstage
       name: backstages.rhdh.redhat.com
+      specDescriptors:
+      - description: Name of the storage class to use for the Persistent Volumes requested
+          by the application. The default storage class name will be used if this
+          field is not specified.
+        displayName: Storage Class for Application volumes
+        path: application.storageClassName
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:StorageClass
+      - description: Name of the storage class to use for the database Persistent
+          Volumes. The default storage class name will be used if this field is not
+          specified.
+        displayName: Storage Class for database volumes
+        path: database.storageClassName
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:StorageClass
       version: v1alpha1
   description: |
     Operator to deploy Backstage on Kubernetes

--- a/bundle/manifests/rhdh.redhat.com_backstages.yaml
+++ b/bundle/manifests/rhdh.redhat.com_backstages.yaml
@@ -263,6 +263,11 @@ spec:
                             type: string
                         type: object
                     type: object
+                  storageClassName:
+                    description: Name of the storage class to use for the Persistent
+                      Volumes requested by the application. The default storage class
+                      name will be used if this field is not specified.
+                    type: string
                 type: object
               database:
                 description: Configuration for database access. Optional.
@@ -282,6 +287,11 @@ spec:
                     description: Control the creation of a local PostgreSQL DB. Set
                       to false if using for example an external Database for Backstage.
                     type: boolean
+                  storageClassName:
+                    description: Name of the storage class to use for the database
+                      Persistent Volumes. The default storage class name will be used
+                      if this field is not specified.
+                    type: string
                 type: object
               rawRuntimeConfig:
                 description: Raw Runtime RuntimeObjects configuration. For Advanced

--- a/config/crd/bases/rhdh.redhat.com_backstages.yaml
+++ b/config/crd/bases/rhdh.redhat.com_backstages.yaml
@@ -264,6 +264,11 @@ spec:
                             type: string
                         type: object
                     type: object
+                  storageClassName:
+                    description: Name of the storage class to use for the Persistent
+                      Volumes requested by the application. The default storage class
+                      name will be used if this field is not specified.
+                    type: string
                 type: object
               database:
                 description: Configuration for database access. Optional.
@@ -283,6 +288,11 @@ spec:
                     description: Control the creation of a local PostgreSQL DB. Set
                       to false if using for example an external Database for Backstage.
                     type: boolean
+                  storageClassName:
+                    description: Name of the storage class to use for the database
+                      Persistent Volumes. The default storage class name will be used
+                      if this field is not specified.
+                    type: string
                 type: object
               rawRuntimeConfig:
                 description: Raw Runtime RuntimeObjects configuration. For Advanced

--- a/config/manifests/bases/backstage-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/backstage-operator.clusterserviceversion.yaml
@@ -16,6 +16,21 @@ spec:
       displayName: Backstage
       kind: Backstage
       name: backstages.rhdh.redhat.com
+      specDescriptors:
+      - description: Name of the storage class to use for the Persistent Volumes requested
+          by the application. The default storage class name will be used if this
+          field is not specified.
+        displayName: Storage Class for Application volumes
+        path: application.storageClassName
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:StorageClass
+      - description: Name of the storage class to use for the database Persistent
+          Volumes. The default storage class name will be used if this field is not
+          specified.
+        displayName: Storage Class for database volumes
+        path: database.storageClassName
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:StorageClass
       version: v1alpha1
   description: |
     Operator to deploy Backstage on Kubernetes

--- a/pkg/model/db-statefulset.go
+++ b/pkg/model/db-statefulset.go
@@ -103,6 +103,13 @@ func (b *DbStatefulSet) validate(model *BackstageModel, backstage bsv1alpha1.Bac
 	} else if model.LocalDbSecret != nil {
 		utils.SetDbSecretEnvVar(b.container(), model.LocalDbSecret.secret.Name)
 	}
+
+	if backstage.Spec.Database != nil && backstage.Spec.Database.StorageClassName != nil {
+		for i := range b.statefulSet.Spec.VolumeClaimTemplates {
+			b.statefulSet.Spec.VolumeClaimTemplates[i].Spec.StorageClassName = backstage.Spec.Database.StorageClassName
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/model/deployment.go
+++ b/pkg/model/deployment.go
@@ -132,6 +132,14 @@ func (b *BackstageDeployment) validate(model *BackstageModel, backstage bsv1alph
 		utils.SetDbSecretEnvVar(b.container(), model.LocalDbSecret.secret.Name)
 	}
 
+	if backstage.Spec.Application != nil && backstage.Spec.Application.StorageClassName != nil {
+		for i, v := range b.deployment.Spec.Template.Spec.Volumes {
+			if v.Ephemeral != nil && v.Ephemeral.VolumeClaimTemplate != nil {
+				b.deployment.Spec.Template.Spec.Volumes[i].Ephemeral.VolumeClaimTemplate.Spec.StorageClassName = backstage.Spec.Application.StorageClassName
+			}
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Description

This PR adds 2 new fields to the CRD:
- `spec.application.storageClassName`
- `spec.database.storageClassName`

They allow configuring the storage classes to be used by the PVCs created by the Operator, i.e., the ephemeral PVC created for the `dynamic-plugins-root` volume, as well as the PVC used by the local database StatefulSet.

https://github.com/janus-idp/operator/pull/388 intended to provide a more generic way to handle this (along with supporting customizing other properties like labels, annotations, resources, sidecar containers, ...), but it currently does not apply to the local database.

Given that https://issues.redhat.com/browse/RHIDP-2705 is a current a blocker for the upcoming 1.2.2 release, this PR is more focused, covering only the storage class use case with the current `v1alpha1` API version.

https://github.com/janus-idp/operator/pull/388 will need to be updated later for 1.3.

**Preview in the OCP console**
![Screenshot from 2024-07-01 12-56-19](https://github.com/janus-idp/operator/assets/593208/0aafdfb8-a90d-4b67-8a60-d4bb9c56f926)


## Which issue(s) does this PR fix or relate to

- Fixes https://issues.redhat.com/browse/RHIDP-2705

## PR acceptance criteria

- [x] Tests
- [ ] Documentation
- [x] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.csv.yaml`](../.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file accordingly

## How to test changes / Special notes to the reviewer

(Tested on a ClusterBot cluster, but feel free to use any storage class on your particular cluster)
```yaml
cat <<EOF | kubectl apply -f -
apiVersion: rhdh.redhat.com/v1alpha1
kind: Backstage
metadata:
  name: developer-hub
spec:
  application:
    storageClassName: "gp2-csi"
  database:
    storageClassName: "gp3-csi"
EOF
```

Then run `kubectl get pvc` and check the storage classes used by the PVCs, e.g.:

```
$ kubectl get pvc
NAME                                                               STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
backstage-backstage-sample-5dbd785b5c-6h7qt-dynamic-plugins-root   Bound    pvc-06f259dc-6c02-4fbd-a6d1-4a78d40ca9ac   2Gi        RWO            gp2-csi        4m43s
data-backstage-psql-backstage-sample-0                             Bound    pvc-2e44619b-cf1c-4d62-bc4c-fea423537648   1Gi        RWO            gp3-csi        4m43s
```