### PR TITLE
docs: Remove the need for adding a Quay token as a global pull secret in the RHDH CI install procedure

### DIFF
--- a/.rhdh/docs/installing-ci-builds.adoc
+++ b/.rhdh/docs/installing-ci-builds.adoc
@@ -9,19 +9,7 @@ WARNING: The procedure below will not work properly on OpenShift clusters with h
 
 *Procedure*
 
-. Add your Quay token to the cluster global pull secret (link:https://docs.openshift.com/container-platform/4.14/openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secrets[link]):
-+
-[source,console]
-----
-oc get secret/pull-secret -n openshift-config --template='{{index .data ".dockerconfigjson" | base64decode}}' > /tmp/my-global-pull-secret.yaml
-oc registry login --registry="quay.io" --auth-basic="<user>:<token>" --to=/tmp/my-global-pull-secret.yaml
-
-oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=/tmp/my-global-pull-secret.yaml
-
-rm -f /tmp/my-global-pull-secret.yaml
-----
-
-. Run the link:../scripts/install-rhdh-catalog-source.sh[installation script] to create the RHDH Operator CatalogSource in your cluster. By default, it installs the Release Candidate version, but the `--next` option allows to install the current development build (from the `main` branch). For example:
+. Run the link:../scripts/install-rhdh-catalog-source.sh[installation script] to create the RHDH Operator CatalogSource in your cluster. By default, it installs the Release Candidate or GA version (from the `1.yy.x` branch), but the `--next` option allows to install the current development build (from the `main` branch). For example:
 +
 [source,console]
 ----


### PR DESCRIPTION
## Description
This is no longer needed since the [rhdh organization](https://quay.io/organization/rhdh) is public on Quay.

## Which issue(s) does this PR fix or relate to

&mdash;

## PR acceptance criteria

- [ ] Tests
- [x] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.csv.yaml`](../.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file accordingly

## How to test changes / Special notes to the reviewer
Just run `.rhdh/scripts/install-rhdh-catalog-source.sh --latest --install-operator rhdh`, and the operator should be installed without any need for adding your Quay token as a global pull secret in OCP.
