### PR TITLE
chore(examples): Use `latest` RHDH image tag and remove useless pull secret in RHDH CR example

### DIFF
--- a/examples/rhdh-cr.yaml
+++ b/examples/rhdh-cr.yaml
@@ -4,7 +4,7 @@ metadata:
   name: my-rhdh
 spec:
   application:
-    image: quay.io/rhdh/rhdh-hub-rhel9:1.0-200
+    image: quay.io/rhdh/rhdh-hub-rhel9:latest
     imagePullSecrets:
       - rhdh-pull-secret
     appConfig:

--- a/examples/rhdh-cr.yaml
+++ b/examples/rhdh-cr.yaml
@@ -5,8 +5,6 @@ metadata:
 spec:
   application:
     image: quay.io/rhdh/rhdh-hub-rhel9:latest
-    imagePullSecrets:
-      - rhdh-pull-secret
     appConfig:
       configMaps:
         - name: app-config-rhdh


### PR DESCRIPTION
## Description
1.0 is no longer supported and does not make sense to be used as example (and in the E2E tests).
'latest' here can be seen as quite stable as it is the latest Release Candidate or GA image.

This also removes the unnecessary image pull secret from the RHDH CR example, because the rhdh organization is public on Quay.

## Which issue(s) does this PR fix or relate to

&mdash;

## PR acceptance criteria

- [x] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.csv.yaml`](../.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file accordingly

## How to test changes / Special notes to the reviewer
`make test-e2e`  against a real cluster should continue to pass.
