### PR TITLE
ci: Run E2E tests against all versions of K8s we claim support for

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -8,14 +8,50 @@ on:
 
 jobs:
   e2e-tests:
+    name: 'E2E Tests (${{ matrix.k8s_version }}) - ${{ matrix.branch }}'
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         branch: [ main, 1.2.x, 1.1.x ]
-    name: E2E Tests - ${{ matrix.branch }}
+        experimental: [ false ]
+        k8s_version:
+          # See https://access.redhat.com/solutions/4870701 for the mapping between OpenShift 4.x and Kubernetes versions.
+          # Per https://access.redhat.com/support/policy/updates/developerhub, we want support for OCP 4.12+, so K8s v1.25+
+          - v1.25.16 # OCP 4.12
+          - v1.26.15 # OCP 4.13
+          - v1.27.15 # OCP 4.14
+          - v1.28.11 # OCP 4.15
+        include:
+          # These are upcoming versions that we don't explicitly claim support for but still want to test against.
+          # Marked as experimental so as not to fail the build, but we still want to capture any useful information in advance in case of failures.
+          - k8s_version: v1.29.6 # OCP 4.16 (not claimed as supported yet)
+            branch: main
+            experimental: true
+          - k8s_version: latest
+            branch: main
+            experimental: true
+          - k8s_version: v1.29.6 # OCP 4.16 (not claimed as supported yet)
+            branch: 1.2.x
+            experimental: true
+          - k8s_version: latest
+            branch: 1.2.x
+            experimental: true
+          - k8s_version: v1.29.6 # OCP 4.16 (not claimed as supported yet)
+            branch: 1.1.x
+            experimental: true
+          - k8s_version: latest
+            branch: 1.1.x
+            experimental: true
+        exclude:
+          # These are the combinations not supported at all and should be excluded
+          - branch: 1.2.x
+            k8s_version: v1.25.16 # OCP v4.12 not supported in 1.2
+          - branch: main
+            k8s_version: v1.25.16 # OCP 4.12 not supported in 1.3+
     concurrency:
-      group: ${{ github.workflow }}-${{ matrix.branch }}
+      group: '${{ github.workflow }}-${{ matrix.branch }}-${{ matrix.k8s_version }}'
       cancel-in-progress: true
     env:
       CONTAINER_ENGINE: podman
@@ -49,9 +85,10 @@ jobs:
 
       - name: Start Minikube
         if: ${{ steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
-        uses: medyagh/setup-minikube@317d92317e473a10540357f1f4b2878b80ee7b95 # v0.0.16
+        uses: medyagh/setup-minikube@d8c0eb871f6f455542491d86a574477bd3894533 # v0.0.18
         with:
           addons: ingress
+          kubernetes-version: ${{ matrix.k8s_version }}
 
       - name: Run E2E tests (Operator Upgrade path)
         # Testing upgrade from 1.1.x


### PR DESCRIPTION
## Description

To help us detect potential issues in advance, this expands the E2E configuration matrix to test several versions of K8s:
- the versions of K8s that map to the OCP versions (https://access.redhat.com/solutions/4870701) that we explicitly claim support for - see https://access.redhat.com/support/policy/updates/developerhub
- some released versions of K8s that are not supported yet. in this case, they are marked as experimental to not fail the Workflow

## Which issue(s) does this PR fix or relate to
&mdash;

## PR acceptance criteria

- [x] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.csv.yaml`](../.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file accordingly

## How to test changes / Special notes to the reviewer
Example of run here: https://github.com/rm3l/janus-idp-operator/actions/runs/9809691738

The failures are not related to the changes here, but to an issue with the default [`janus-idp/backstage-showcase`](https://quay.io/repository/janus-idp/backstage-showcase?tab=tags) image's `latest` tag being outdated, and recently-merged https://github.com/janus-idp/operator/pull/390 only works in 1.2+. See https://redhat-internal.slack.com/archives/C04CUSD4JSG/p1720191475569659