### PR TITLE
chore: Switch the default operand image tag from `latest` to `next` and fix CI nightly job [RHIDP-3157]

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -49,9 +49,7 @@ jobs:
 
       - name: Start Minikube
         if: ${{ steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
-        uses: medyagh/setup-minikube@317d92317e473a10540357f1f4b2878b80ee7b95 # v0.0.16
-        with:
-          addons: ingress
+        uses: medyagh/setup-minikube@d8c0eb871f6f455542491d86a574477bd3894533 # v0.0.18
 
       - name: Run E2E tests (Operator Upgrade path)
         # Testing upgrade from 1.1.x

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -13,9 +13,13 @@ jobs:
       fail-fast: false
       matrix:
         branch: [ main, 1.2.x, 1.1.x ]
-    name: E2E Tests - ${{ matrix.branch }}
+        test_upgrade: [ 'true', 'false' ]
+        exclude:
+          - branch: 1.1.x # Testing upgrade from 1.1.x
+            test_upgrade: 'true'
+    name: 'E2E Tests - ${{ matrix.branch }} - upgrade=${{ matrix.test_upgrade }}'
     concurrency:
-      group: ${{ github.workflow }}-${{ matrix.branch }}
+      group: '${{ github.workflow }}-${{ matrix.branch }}-${{ matrix.test_upgrade }}'
       cancel-in-progress: true
     env:
       CONTAINER_ENGINE: podman
@@ -52,15 +56,14 @@ jobs:
         uses: medyagh/setup-minikube@d8c0eb871f6f455542491d86a574477bd3894533 # v0.0.18
 
       - name: Run E2E tests (Operator Upgrade path)
-        # Testing upgrade from 1.1.x
-        if: ${{ matrix.branch != '1.1.x' && steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
+        if: ${{ matrix.test_upgrade == 'true' && steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
         env:
           BACKSTAGE_OPERATOR_TESTS_PLATFORM: minikube
           IMG: ${{ env.OPERATOR_IMAGE }}
         run: make test-e2e-upgrade
 
       - name: Run E2E tests
-        if: ${{ steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
+        if: ${{ matrix.test_upgrade == 'false' && steps.operator-image-existence-checker.outputs.OPERATOR_IMAGE_EXISTS == 'true' }}
         env:
           BACKSTAGE_OPERATOR_TESTS_PLATFORM: minikube
           IMG: ${{ env.OPERATOR_IMAGE }}

--- a/bundle/manifests/backstage-default-config_v1_configmap.yaml
+++ b/bundle/manifests/backstage-default-config_v1_configmap.yaml
@@ -191,7 +191,8 @@ data:
               command:
                 - ./install-dynamic-plugins.sh
                 - /dynamic-plugins-root
-              image: quay.io/janus-idp/backstage-showcase:latest # will be replaced with the actual image quay.io/janus-idp/backstage-showcase:next
+              # image will be replaced by the value of the `RELATED_IMAGE_backstage` env var, if set
+              image: quay.io/janus-idp/backstage-showcase:next
               imagePullPolicy: IfNotPresent
               securityContext:
                 runAsNonRoot: true
@@ -218,7 +219,7 @@ data:
           containers:
             - name: backstage-backend
               # image will be replaced by the value of the `RELATED_IMAGE_backstage` env var, if set
-              image: quay.io/janus-idp/backstage-showcase:latest
+              image: quay.io/janus-idp/backstage-showcase:next
               imagePullPolicy: IfNotPresent
               args:
                 - "--config"

--- a/bundle/manifests/backstage-default-config_v1_configmap.yaml
+++ b/bundle/manifests/backstage-default-config_v1_configmap.yaml
@@ -191,7 +191,7 @@ data:
               command:
                 - ./install-dynamic-plugins.sh
                 - /dynamic-plugins-root
-              image: quay.io/rhdh/rhdh-hub-rhel9:latest # will be replaced by the value of the `RELATED_IMAGE_backstage` env var, if set
+              image: quay.io/janus-idp/backstage-showcase:latest # will be replaced with the actual image quay.io/janus-idp/backstage-showcase:next
               imagePullPolicy: IfNotPresent
               securityContext:
                 runAsNonRoot: true
@@ -218,7 +218,7 @@ data:
           containers:
             - name: backstage-backend
               # image will be replaced by the value of the `RELATED_IMAGE_backstage` env var, if set
-              image: quay.io/rhdh/rhdh-hub-rhel9:latest
+              image: quay.io/janus-idp/backstage-showcase:latest
               imagePullPolicy: IfNotPresent
               args:
                 - "--config"

--- a/bundle/manifests/backstage-default-config_v1_configmap.yaml
+++ b/bundle/manifests/backstage-default-config_v1_configmap.yaml
@@ -191,7 +191,7 @@ data:
               command:
                 - ./install-dynamic-plugins.sh
                 - /dynamic-plugins-root
-              image: quay.io/janus-idp/backstage-showcase:latest # will be replaced with the actual image quay.io/janus-idp/backstage-showcase:next
+              image: quay.io/rhdh/rhdh-hub-rhel9:latest # will be replaced by the value of the `RELATED_IMAGE_backstage` env var, if set
               imagePullPolicy: IfNotPresent
               securityContext:
                 runAsNonRoot: true
@@ -218,7 +218,7 @@ data:
           containers:
             - name: backstage-backend
               # image will be replaced by the value of the `RELATED_IMAGE_backstage` env var, if set
-              image: quay.io/janus-idp/backstage-showcase:latest
+              image: quay.io/rhdh/rhdh-hub-rhel9:latest
               imagePullPolicy: IfNotPresent
               args:
                 - "--config"

--- a/bundle/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/backstage-operator.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2024-07-08T12:45:16Z"
+    createdAt: "2024-07-16T16:00:50Z"
     operatorframework.io/suggested-namespace: backstage-system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -213,7 +213,7 @@ spec:
                 - name: RELATED_IMAGE_postgresql
                   value: quay.io/fedora/postgresql-15:latest
                 - name: RELATED_IMAGE_backstage
-                  value: quay.io/janus-idp/backstage-showcase:latest
+                  value: quay.io/janus-idp/backstage-showcase:next
                 image: quay.io/janus-idp/operator:0.3.0
                 livenessProbe:
                   httpGet:
@@ -317,6 +317,6 @@ spec:
   relatedImages:
   - image: quay.io/fedora/postgresql-15:latest
     name: postgresql
-  - image: quay.io/janus-idp/backstage-showcase:latest
+  - image: quay.io/janus-idp/backstage-showcase:next
     name: backstage
   version: 0.3.0

--- a/bundle/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/backstage-operator.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2024-07-12T14:27:27Z"
+    createdAt: "2024-07-08T12:45:16Z"
     operatorframework.io/suggested-namespace: backstage-system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -213,7 +213,7 @@ spec:
                 - name: RELATED_IMAGE_postgresql
                   value: quay.io/fedora/postgresql-15:latest
                 - name: RELATED_IMAGE_backstage
-                  value: quay.io/rhdh/rhdh-hub-rhel9:latest
+                  value: quay.io/janus-idp/backstage-showcase:latest
                 image: quay.io/janus-idp/operator:0.3.0
                 livenessProbe:
                   httpGet:
@@ -317,6 +317,6 @@ spec:
   relatedImages:
   - image: quay.io/fedora/postgresql-15:latest
     name: postgresql
-  - image: quay.io/rhdh/rhdh-hub-rhel9:latest
+  - image: quay.io/janus-idp/backstage-showcase:latest
     name: backstage
   version: 0.3.0

--- a/bundle/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/backstage-operator.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2024-07-08T12:45:16Z"
+    createdAt: "2024-07-12T14:27:27Z"
     operatorframework.io/suggested-namespace: backstage-system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -213,7 +213,7 @@ spec:
                 - name: RELATED_IMAGE_postgresql
                   value: quay.io/fedora/postgresql-15:latest
                 - name: RELATED_IMAGE_backstage
-                  value: quay.io/janus-idp/backstage-showcase:latest
+                  value: quay.io/rhdh/rhdh-hub-rhel9:latest
                 image: quay.io/janus-idp/operator:0.3.0
                 livenessProbe:
                   httpGet:
@@ -317,6 +317,6 @@ spec:
   relatedImages:
   - image: quay.io/fedora/postgresql-15:latest
     name: postgresql
-  - image: quay.io/janus-idp/backstage-showcase:latest
+  - image: quay.io/rhdh/rhdh-hub-rhel9:latest
     name: backstage
   version: 0.3.0

--- a/config/manager/default-config/deployment.yaml
+++ b/config/manager/default-config/deployment.yaml
@@ -38,7 +38,8 @@ spec:
           command:
             - ./install-dynamic-plugins.sh
             - /dynamic-plugins-root
-          image: quay.io/janus-idp/backstage-showcase:latest # will be replaced with the actual image quay.io/janus-idp/backstage-showcase:next
+          # image will be replaced by the value of the `RELATED_IMAGE_backstage` env var, if set
+          image: quay.io/janus-idp/backstage-showcase:next
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true
@@ -65,7 +66,7 @@ spec:
       containers:
         - name: backstage-backend
           # image will be replaced by the value of the `RELATED_IMAGE_backstage` env var, if set
-          image: quay.io/janus-idp/backstage-showcase:latest
+          image: quay.io/janus-idp/backstage-showcase:next
           imagePullPolicy: IfNotPresent
           args:
             - "--config"

--- a/config/manager/default-config/deployment.yaml
+++ b/config/manager/default-config/deployment.yaml
@@ -38,7 +38,7 @@ spec:
           command:
             - ./install-dynamic-plugins.sh
             - /dynamic-plugins-root
-          image: quay.io/rhdh/rhdh-hub-rhel9:latest # will be replaced by the value of the `RELATED_IMAGE_backstage` env var, if set
+          image: quay.io/janus-idp/backstage-showcase:latest # will be replaced with the actual image quay.io/janus-idp/backstage-showcase:next
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true
@@ -65,7 +65,7 @@ spec:
       containers:
         - name: backstage-backend
           # image will be replaced by the value of the `RELATED_IMAGE_backstage` env var, if set
-          image: quay.io/rhdh/rhdh-hub-rhel9:latest
+          image: quay.io/janus-idp/backstage-showcase:latest
           imagePullPolicy: IfNotPresent
           args:
             - "--config"

--- a/config/manager/default-config/deployment.yaml
+++ b/config/manager/default-config/deployment.yaml
@@ -38,7 +38,7 @@ spec:
           command:
             - ./install-dynamic-plugins.sh
             - /dynamic-plugins-root
-          image: quay.io/janus-idp/backstage-showcase:latest # will be replaced with the actual image quay.io/janus-idp/backstage-showcase:next
+          image: quay.io/rhdh/rhdh-hub-rhel9:latest # will be replaced by the value of the `RELATED_IMAGE_backstage` env var, if set
           imagePullPolicy: IfNotPresent
           securityContext:
             runAsNonRoot: true
@@ -65,7 +65,7 @@ spec:
       containers:
         - name: backstage-backend
           # image will be replaced by the value of the `RELATED_IMAGE_backstage` env var, if set
-          image: quay.io/janus-idp/backstage-showcase:latest
+          image: quay.io/rhdh/rhdh-hub-rhel9:latest
           imagePullPolicy: IfNotPresent
           args:
             - "--config"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -76,7 +76,7 @@ spec:
         - name: RELATED_IMAGE_postgresql
           value: quay.io/fedora/postgresql-15:latest
         - name: RELATED_IMAGE_backstage
-          value: quay.io/janus-idp/backstage-showcase:latest
+          value: quay.io/janus-idp/backstage-showcase:next
         image: controller:latest
         name: manager
         securityContext:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -76,7 +76,7 @@ spec:
         - name: RELATED_IMAGE_postgresql
           value: quay.io/fedora/postgresql-15:latest
         - name: RELATED_IMAGE_backstage
-          value: quay.io/rhdh/rhdh-hub-rhel9:latest
+          value: quay.io/janus-idp/backstage-showcase:latest
         image: controller:latest
         name: manager
         securityContext:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -76,7 +76,7 @@ spec:
         - name: RELATED_IMAGE_postgresql
           value: quay.io/fedora/postgresql-15:latest
         - name: RELATED_IMAGE_backstage
-          value: quay.io/janus-idp/backstage-showcase:latest
+          value: quay.io/rhdh/rhdh-hub-rhel9:latest
         image: controller:latest
         name: manager
         securityContext:

--- a/examples/bs1.yaml
+++ b/examples/bs1.yaml
@@ -2,6 +2,3 @@ apiVersion: rhdh.redhat.com/v1alpha2
 kind: Backstage
 metadata:
   name: bs1
-
-
-

--- a/examples/rhdh-cr-with-app-configs.yaml
+++ b/examples/rhdh-cr-with-app-configs.yaml
@@ -47,10 +47,16 @@ data:
     backend:
       auth:
         externalAccess:
-            - type: legacy
-              options:
-                subject: legacy-default-config
-                secret: "${BACKEND_SECRET}"
+          - type: legacy
+            options:
+              subject: legacy-default-config
+              secret: "${BACKEND_SECRET}"
+    auth:
+      environment: development
+      providers:
+        guest:
+          # using the guest user to query the '/api/dynamic-plugins-info/loaded-plugins' endpoint.
+          dangerouslyAllowOutsideDevelopment: true
 ---
 apiVersion: v1
 kind: Secret
@@ -128,7 +134,7 @@ data:
                     initialDelay: { seconds: 15}
       - package: ./dynamic-plugins/dist/backstage-plugin-techdocs-backend-dynamic
         pluginConfig:
-          # Reference documentation http://backstage.io/docs/features/techdocs/configuration
+          # Reference documentation https://backstage.io/docs/features/techdocs/configuration
           # Note: After experimenting with basic setup, use CI/CD to generate docs
           # and an external cloud storage when deploying TechDocs for production use-case.
           # https://backstage.io/docs/features/techdocs/how-to-guides#how-to-migrate-from-techdocs-basic-to-recommended-deployment-approach

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -223,6 +223,16 @@ func verifyControllerUp(g Gomega, managerPodLabel string) {
 	g.Expect(string(status)).Should(Equal("Running"), fmt.Sprintf("controller pod in %s status", status))
 }
 
+func getControllerLogs(managerPodLabel string) string {
+	// Get pod name
+	cmd := exec.Command(helper.GetPlatformTool(), "logs",
+		"-l", managerPodLabel,
+		"-n", _namespace,
+	)
+	output, _ := helper.Run(cmd)
+	return string(output)
+}
+
 func uninstallOperator() {
 	switch testMode {
 	case rhdhLatestTestMode, rhdhNextTestMode, rhdhAirgapTestMode:

--- a/tests/e2e/e2e_suite_test.go
+++ b/tests/e2e/e2e_suite_test.go
@@ -223,11 +223,10 @@ func verifyControllerUp(g Gomega, managerPodLabel string) {
 	g.Expect(string(status)).Should(Equal("Running"), fmt.Sprintf("controller pod in %s status", status))
 }
 
-func getControllerLogs(managerPodLabel string) string {
-	// Get pod name
+func getPodLogs(ns string, label string) string {
 	cmd := exec.Command(helper.GetPlatformTool(), "logs",
-		"-l", managerPodLabel,
-		"-n", _namespace,
+		"-l", label,
+		"-n", ns,
 	)
 	output, _ := helper.Run(cmd)
 	return string(output)

--- a/tests/e2e/e2e_upgrade_test.go
+++ b/tests/e2e/e2e_upgrade_test.go
@@ -93,7 +93,8 @@ var _ = Describe("Operator upgrade with existing instances", func() {
 			})
 
 			By("checking the status of the existing CR")
-			Eventually(helper.VerifyBackstageCRStatus, 5*time.Minute, time.Second).WithArguments(ns, crName, `"reason":"Deployed"`).Should(Succeed())
+			Eventually(helper.VerifyBackstageCRStatus, 5*time.Minute, time.Second).WithArguments(ns, crName, `"reason":"Deployed"`).
+				Should(Succeed(), fmt.Sprintf("=== Operator logs ===\n%s\n", getControllerLogs(managerPodLabel)))
 
 			By("checking the Backstage operand pod")
 			Eventually(func(g Gomega) {

--- a/tests/e2e/e2e_upgrade_test.go
+++ b/tests/e2e/e2e_upgrade_test.go
@@ -100,11 +100,11 @@ metadata:
 		It("should successfully reconcile existing CR when upgrading the operator", func() {
 			By("Upgrading the operator", func() {
 				installOperatorWithMakeDeploy(false)
-				EventuallyWithOffset(1, verifyControllerUp, 5*time.Minute, time.Second).WithArguments(managerPodLabel).Should(Succeed())
+				EventuallyWithOffset(1, verifyControllerUp, 5*time.Minute, 3*time.Second).WithArguments(managerPodLabel).Should(Succeed())
 			})
 
 			By("checking the status of the existing CR")
-			Eventually(helper.VerifyBackstageCRStatus, 5*time.Minute, time.Second).WithArguments(ns, crName, `"reason":"Deployed"`).
+			Eventually(helper.VerifyBackstageCRStatus, 5*time.Minute, 3*time.Second).WithArguments(ns, crName, `"reason":"Deployed"`).
 				Should(Succeed(), func() string {
 					return fmt.Sprintf("=== Operator logs ===\n%s\n", getPodLogs(_namespace, managerPodLabel))
 				})
@@ -123,7 +123,7 @@ metadata:
 				g.Expect(err).ShouldNot(HaveOccurred())
 				podNames := helper.GetNonEmptyLines(string(podOutput))
 				g.Expect(podNames).Should(HaveLen(1), fmt.Sprintf("expected 1 Backstage operand pod(s) running, but got %d", len(podNames)))
-			}, 5*time.Minute, time.Second).Should(Succeed(), func() string {
+			}, 10*time.Minute, 5*time.Second).Should(Succeed(), func() string {
 				return fmt.Sprintf("=== Operand logs ===\n%s\n", getPodLogs(ns, crLabel))
 			})
 		})

--- a/tests/e2e/e2e_upgrade_test.go
+++ b/tests/e2e/e2e_upgrade_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Operator upgrade with existing instances", func() {
 			})
 
 			By("checking the status of the existing CR")
-			Eventually(helper.VerifyBackstageCRStatus, time.Minute, time.Second).WithArguments(ns, crName, `"reason":"Deployed"`).Should(Succeed())
+			Eventually(helper.VerifyBackstageCRStatus, 5*time.Minute, time.Second).WithArguments(ns, crName, `"reason":"Deployed"`).Should(Succeed())
 
 			By("checking the Backstage operand pod")
 			Eventually(func(g Gomega) {

--- a/tests/e2e/testdata/backstage-operator-0.1.3.yaml
+++ b/tests/e2e/testdata/backstage-operator-0.1.3.yaml
@@ -739,7 +739,7 @@ data:
                 - name: NPM_CONFIG_USERCONFIG
                   value: /opt/app-root/src/.npmrc.dynamic-plugins
               # image will be replaced by the value of the `RELATED_IMAGE_backstage` env var, if set
-              image: quay.io/janus-idp/backstage-showcase:latest
+              image: quay.io/janus-idp/backstage-showcase:next
               imagePullPolicy: IfNotPresent
               name: install-dynamic-plugins
               volumeMounts:
@@ -761,7 +761,7 @@ data:
           containers:
             - name: backstage-backend
               # image will be replaced by the value of the `RELATED_IMAGE_backstage` env var, if set
-              image: quay.io/janus-idp/backstage-showcase:latest
+              image: quay.io/janus-idp/backstage-showcase:next
               imagePullPolicy: IfNotPresent
               args:
                 - "--config"
@@ -949,7 +949,7 @@ spec:
             - name: RELATED_IMAGE_postgresql
               value: quay.io/fedora/postgresql-15:latest
             - name: RELATED_IMAGE_backstage
-              value: quay.io/janus-idp/backstage-showcase:latest
+              value: quay.io/janus-idp/backstage-showcase:next
           # TODO(asoro): Default image is 'quay.io/janus-idp/operator:0.1.3' on 1.1.x,
           # but replaced by the one from RHDH, because the Janus-IDP image expires after 14d if not updated.
           image: quay.io/rhdh/rhdh-rhel9-operator:1.1

--- a/tests/e2e/testdata/backstage-operator-0.1.3.yaml
+++ b/tests/e2e/testdata/backstage-operator-0.1.3.yaml
@@ -739,7 +739,7 @@ data:
                 - name: NPM_CONFIG_USERCONFIG
                   value: /opt/app-root/src/.npmrc.dynamic-plugins
               # image will be replaced by the value of the `RELATED_IMAGE_backstage` env var, if set
-              image: quay.io/rhdh/rhdh-hub-rhel9:1.1
+              image: quay.io/janus-idp/backstage-showcase:latest
               imagePullPolicy: IfNotPresent
               name: install-dynamic-plugins
               volumeMounts:
@@ -761,7 +761,7 @@ data:
           containers:
             - name: backstage-backend
               # image will be replaced by the value of the `RELATED_IMAGE_backstage` env var, if set
-              image: quay.io/rhdh/rhdh-hub-rhel9:1.1
+              image: quay.io/janus-idp/backstage-showcase:latest
               imagePullPolicy: IfNotPresent
               args:
                 - "--config"
@@ -949,7 +949,7 @@ spec:
             - name: RELATED_IMAGE_postgresql
               value: quay.io/fedora/postgresql-15:latest
             - name: RELATED_IMAGE_backstage
-              value: quay.io/rhdh/rhdh-hub-rhel9:1.1
+              value: quay.io/janus-idp/backstage-showcase:latest
           # TODO(asoro): Default image is 'quay.io/janus-idp/operator:0.1.3' on 1.1.x,
           # but replaced by the one from RHDH, because the Janus-IDP image expires after 14d if not updated.
           image: quay.io/rhdh/rhdh-rhel9-operator:1.1

--- a/tests/e2e/testdata/backstage-operator-0.1.3.yaml
+++ b/tests/e2e/testdata/backstage-operator-0.1.3.yaml
@@ -739,7 +739,7 @@ data:
                 - name: NPM_CONFIG_USERCONFIG
                   value: /opt/app-root/src/.npmrc.dynamic-plugins
               # image will be replaced by the value of the `RELATED_IMAGE_backstage` env var, if set
-              image: quay.io/janus-idp/backstage-showcase:latest
+              image: quay.io/rhdh/rhdh-hub-rhel9:1.1
               imagePullPolicy: IfNotPresent
               name: install-dynamic-plugins
               volumeMounts:
@@ -761,7 +761,7 @@ data:
           containers:
             - name: backstage-backend
               # image will be replaced by the value of the `RELATED_IMAGE_backstage` env var, if set
-              image: quay.io/janus-idp/backstage-showcase:latest
+              image: quay.io/rhdh/rhdh-hub-rhel9:1.1
               imagePullPolicy: IfNotPresent
               args:
                 - "--config"
@@ -949,7 +949,7 @@ spec:
             - name: RELATED_IMAGE_postgresql
               value: quay.io/fedora/postgresql-15:latest
             - name: RELATED_IMAGE_backstage
-              value: quay.io/janus-idp/backstage-showcase:latest
+              value: quay.io/rhdh/rhdh-hub-rhel9:1.1
           # TODO(asoro): Default image is 'quay.io/janus-idp/operator:0.1.3' on 1.1.x,
           # but replaced by the one from RHDH, because the Janus-IDP image expires after 14d if not updated.
           image: quay.io/rhdh/rhdh-rhel9-operator:1.1


### PR DESCRIPTION
## Description
This PR fixes the failing nightly job by:
- switching the default operand image from `quay.io/janus-idp/backstage-showcase:latest` to ~`quay.io/rhdh/rhdh-hub-rhel9:latest`~ `quay.io/janus-idp/backstage-showcase:next`.
We'll need to monitor our tests to see how they behave against this `next` tag (built from the `main` branch of the Showcase repo). If they are too unstable, we might need to switch back to using a stable (and updated) downstream RHDH image.
- making sure to handle the required (RHDH 1.2+) authentication to the `/api/dynamic-plugins-info/loaded-plugins` endpoint (used in the tests to ensure a fully-working CR example)

## Which issue(s) does this PR fix or relate to

- Fixes https://issues.redhat.com/browse/RHIDP-3157

## PR acceptance criteria

- [x] Tests
- [ ] Documentation
- [x] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.csv.yaml`](../.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file accordingly

## How to test changes / Special notes to the reviewer

See https://github.com/rm3l/janus-idp-operator/actions/runs/9960353647/job/27520205261 as an example of a successful run.
