### PR TITLE
fix(examples): Fix key in ConfigMap used in example CR with `rawRuntimeConfig` [RHDHBUGS-44]

### DIFF
--- a/examples/postgres-secret.yaml
+++ b/examples/postgres-secret.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: postgres-secrets
-  namespace: backstage
 type: Opaque
 stringData:
   POSTGRES_PASSWORD: admin12345

--- a/examples/showcase-config.yaml
+++ b/examples/showcase-config.yaml
@@ -3,7 +3,7 @@ kind: ConfigMap
 metadata:
   name: showcase-config
 data:
-  deploy: |-
+  deployment.yaml: |-
     apiVersion: apps/v1
     kind: Deployment
     metadata:


### PR DESCRIPTION
## Description
A user relied on this example to override their raw config, but the operator silently ignored it.

## Which issue(s) does this PR fix or relate to

- Fixes https://issues.redhat.com/browse/RHDHBUGS-44

## PR acceptance criteria

- [ ] Tests
- [ ] Documentation
- [ ] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.csv.yaml`](../.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file accordingly

## How to test changes / Special notes to the reviewer
```
kubectl apply -f examples/postgres-secret.yaml
kubectl apply -f examples/showcase-config.yaml
kubectl apply -f examples/showcase-cr.yaml
```

Should work and should apply the custom config.