### PR TITLE
Rhidp 1148 add external db note

### DIFF
--- a/.rhdh/bundle/manifests/rhdh-operator.csv.yaml
+++ b/.rhdh/bundle/manifests/rhdh-operator.csv.yaml
@@ -21,10 +21,12 @@ metadata:
     certified: 'true'
     containerImage: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-rhel9-operator:1.3
     createdAt: "2023-03-20T16:11:34Z"
-    description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
-      It comes with pre-built plug-ins, configuration settings, and deployment mechanisms,
-      which can help streamline the process of setting up a self-managed internal
+    description: |
+      Red Hat Developer Hub is a Red Hat supported version of Backstage.
+      It comes with pre-built plug-ins and configuration settings, supports use of an external database, and can
+      help streamline the process of setting up a self-managed internal
       developer portal for adopters who are just starting out.
+      Link: https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.2/html/administration_guide_for_red_hat_developer_hub/assembly-configuring-external-postgresql-databases#assembly-configuring-external-postgresql-databases
     operatorframework.io/suggested-namespace: rhdh-operator
     operators.openshift.io/valid-subscription: '["Red Hat Developer Hub"]'
     operators.operatorframework.io/builder: operator-sdk-v1.33.0

--- a/.rhdh/bundle/manifests/rhdh-operator.csv.yaml
+++ b/.rhdh/bundle/manifests/rhdh-operator.csv.yaml
@@ -21,12 +21,10 @@ metadata:
     certified: 'true'
     containerImage: registry-proxy.engineering.redhat.com/rh-osbs/rhdh-rhdh-rhel9-operator:1.3
     createdAt: "2023-03-20T16:11:34Z"
-    description: |
-      Red Hat Developer Hub is a Red Hat supported version of Backstage.
+    description: Red Hat Developer Hub is a Red Hat supported version of Backstage.
       It comes with pre-built plug-ins and configuration settings, supports use of an external database, and can
       help streamline the process of setting up a self-managed internal
       developer portal for adopters who are just starting out.
-      Link: https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.2/html/administration_guide_for_red_hat_developer_hub/assembly-configuring-external-postgresql-databases#assembly-configuring-external-postgresql-databases
     operatorframework.io/suggested-namespace: rhdh-operator
     operators.openshift.io/valid-subscription: '["Red Hat Developer Hub"]'
     operators.operatorframework.io/builder: operator-sdk-v1.33.0

--- a/.rhdh/bundle/manifests/rhdh-operator.csv.yaml
+++ b/.rhdh/bundle/manifests/rhdh-operator.csv.yaml
@@ -82,6 +82,7 @@ spec:
     * [Product Documentation](https://access.redhat.com/documentation/en-us/red_hat_developer_hub)
     * [Life Cycle](https://access.redhat.com/node/7025299)
     * [Support Policies](https://access.redhat.com/policy/developerhub-support-policy)
+    * [Configuring external PostgreSQL databases](https://docs.redhat.com/en/documentation/red_hat_developer_hub/1.2/html/administration_guide_for_red_hat_developer_hub/assembly-configuring-external-postgresql-databases#assembly-configuring-external-postgresql-databases)
     
   displayName: Red Hat Developer Hub Operator
   icon:


### PR DESCRIPTION
Instead of adding a lengthy link at the end of the description paragraph, we decided to include the link as a markdown link at the end of the More Information list of markdown links. Related issue: https://issues.redhat.com/browse/RHIDP-1148?filter=-1

![e](https://github.com/user-attachments/assets/7989b450-e4dc-42f5-a9e2-f7583d36b5ba)



