### PR TITLE
docs: add note in CRD that using Routes with external certificates in TLS Secrets is Technical Preview in OCP [RHDHBUGS-45]

### DIFF
--- a/api/v1alpha1/backstage_types.go
+++ b/api/v1alpha1/backstage_types.go
@@ -260,6 +260,8 @@ type TLS struct {
 	// chain. Do not include a CA certificate. The secret referenced should
 	// be present in the same namespace as that of the Route.
 	// Forbidden when `certificate` is set.
+	// Note that securing Routes with external certificates in TLS secrets is a Technology Preview feature in OpenShift,
+	// and requires enabling the `RouteExternalCertificate` OpenShift Feature Gate and might not be functionally complete.
 	// +optional
 	ExternalCertificateSecretName string `json:"externalCertificateSecretName,omitempty"`
 

--- a/api/v1alpha2/backstage_types.go
+++ b/api/v1alpha2/backstage_types.go
@@ -275,6 +275,8 @@ type TLS struct {
 	// chain. Do not include a CA certificate. The secret referenced should
 	// be present in the same namespace as that of the Route.
 	// Forbidden when `certificate` is set.
+	// Note that securing Routes with external certificates in TLS secrets is a Technology Preview feature in OpenShift,
+	// and requires enabling the `RouteExternalCertificate` OpenShift Feature Gate and might not be functionally complete.
 	// +optional
 	ExternalCertificateSecretName string `json:"externalCertificateSecretName,omitempty"`
 

--- a/bundle/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/backstage-operator.clusterserviceversion.yaml
@@ -21,7 +21,7 @@ metadata:
         }
       ]
     capabilities: Seamless Upgrades
-    createdAt: "2024-07-16T20:47:15Z"
+    createdAt: "2024-07-25T11:50:13Z"
     operatorframework.io/suggested-namespace: backstage-system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3

--- a/bundle/manifests/rhdh.redhat.com_backstages.yaml
+++ b/bundle/manifests/rhdh.redhat.com_backstages.yaml
@@ -260,7 +260,11 @@ spec:
                               serving certificate, not a certificate chain. Do not
                               include a CA certificate. The secret referenced should
                               be present in the same namespace as that of the Route.
-                              Forbidden when `certificate` is set.
+                              Forbidden when `certificate` is set. Note that securing
+                              Routes with external certificates in TLS secrets is
+                              a Technology Preview feature in OpenShift, and requires
+                              enabling the `RouteExternalCertificate` OpenShift Feature
+                              Gate and might not be functionally complete.
                             type: string
                           key:
                             description: key provides key file contents
@@ -622,7 +626,11 @@ spec:
                               serving certificate, not a certificate chain. Do not
                               include a CA certificate. The secret referenced should
                               be present in the same namespace as that of the Route.
-                              Forbidden when `certificate` is set.
+                              Forbidden when `certificate` is set. Note that securing
+                              Routes with external certificates in TLS secrets is
+                              a Technology Preview feature in OpenShift, and requires
+                              enabling the `RouteExternalCertificate` OpenShift Feature
+                              Gate and might not be functionally complete.
                             type: string
                           key:
                             description: key provides key file contents

--- a/config/crd/bases/rhdh.redhat.com_backstages.yaml
+++ b/config/crd/bases/rhdh.redhat.com_backstages.yaml
@@ -261,7 +261,11 @@ spec:
                               serving certificate, not a certificate chain. Do not
                               include a CA certificate. The secret referenced should
                               be present in the same namespace as that of the Route.
-                              Forbidden when `certificate` is set.
+                              Forbidden when `certificate` is set. Note that securing
+                              Routes with external certificates in TLS secrets is
+                              a Technology Preview feature in OpenShift, and requires
+                              enabling the `RouteExternalCertificate` OpenShift Feature
+                              Gate and might not be functionally complete.
                             type: string
                           key:
                             description: key provides key file contents
@@ -623,7 +627,11 @@ spec:
                               serving certificate, not a certificate chain. Do not
                               include a CA certificate. The secret referenced should
                               be present in the same namespace as that of the Route.
-                              Forbidden when `certificate` is set.
+                              Forbidden when `certificate` is set. Note that securing
+                              Routes with external certificates in TLS secrets is
+                              a Technology Preview feature in OpenShift, and requires
+                              enabling the `RouteExternalCertificate` OpenShift Feature
+                              Gate and might not be functionally complete.
                             type: string
                           key:
                             description: key provides key file contents


### PR DESCRIPTION
## Description

This is a follow-up to https://issues.redhat.com/browse/RHDHBUGS-45

Right now, using the Operator, a user can reference an external certificate as a Secret in their CR, like so:

```yaml
spec: 
  application: 
    route: 
      enabled: true
      host: my-rhdh.apps.example.com
      tls: 
        externalCertificateSecretName: my-rhdh-tls-cert
```

However, as depicted in https://docs.openshift.com/container-platform/4.16/networking/routes/secured-routes.html#nw-ingress-route-secret-load-external-cert_secured-routes, **Securing route with external certificates in TLS secrets is a Technology Preview feature only**. As such, it requires enabling the `RouteExternalCertificate` Feature Gate in OpenShift.

This updates the doc about the `spec.application.route.tls.externalCertificateSecretName` CRD field accordingly.

Note that there is a dedicated issue for the product docs team to call this out: https://issues.redhat.com/browse/RHIDP-3292

## Which issue(s) does this PR fix or relate to

- Relates to https://issues.redhat.com/browse/RHDHBUGS-45
- Relates to https://issues.redhat.com/browse/RHIDP-3292

## PR acceptance criteria

- [ ] Tests
- [x] Documentation
- [x] If the bundle manifests have been updated, make sure to review the [`rhdh-operator.csv.yaml`](../.rhdh/bundle/manifests/rhdh-operator.csv.yaml) file accordingly

## How to test changes / Special notes to the reviewer

Preview of how this looks like in the OCP web console:

![image](https://github.com/user-attachments/assets/4275fd30-6324-444a-938c-71755d89a420)

