### PR TITLE
feat: tagRelease.sh bump versions in 1.2.x for 1.2 release

### DIFF
--- a/.rhdh/bundle/manifests/rhdh-operator.csv.yaml
+++ b/.rhdh/bundle/manifests/rhdh-operator.csv.yaml
@@ -42,8 +42,8 @@ metadata:
     features.operators.openshift.io/token-auth-gcp: "false"
     repository: https://gitlab.cee.redhat.com/rhidp/rhdh/
     support: Red Hat
-    skipRange: '>=1.0.0 <1.2.2'
-  name: rhdh-operator.v1.2.2
+    skipRange: '>=1.0.0 <1.2.3'
+  name: rhdh-operator.v1.2.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -354,5 +354,5 @@ spec:
   provider:
     name: Red Hat Inc.
     url: https://www.redhat.com/
-  version: 1.2.2
+  version: 1.2.3
   replaces: rhdh-operator.v1.1.1

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.2.2
+VERSION ?= 0.2.3
 
 # Using docker or podman to build and push images
 CONTAINER_ENGINE ?= docker

--- a/bundle/manifests/backstage-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/backstage-operator.clusterserviceversion.yaml
@@ -25,8 +25,8 @@ metadata:
     operatorframework.io/suggested-namespace: backstage-system
     operators.operatorframework.io/builder: operator-sdk-v1.33.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-    skipRange: '>=0.0.1 <0.2.2'
-  name: backstage-operator.v0.2.2
+    skipRange: '>=0.0.1 <0.2.3'
+  name: backstage-operator.v0.2.3
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -212,7 +212,7 @@ spec:
                   value: quay.io/fedora/postgresql-15:latest
                 - name: RELATED_IMAGE_backstage
                   value: quay.io/janus-idp/backstage-showcase:latest
-                image: quay.io/janus-idp/operator:0.2.2
+                image: quay.io/janus-idp/operator:0.2.3
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -317,4 +317,4 @@ spec:
     name: postgresql
   - image: quay.io/janus-idp/backstage-showcase:latest
     name: backstage
-  version: 0.2.2
+  version: 0.2.3


### PR DESCRIPTION
Signed-off-by: Nick Boldt <nboldt@redhat.com>
